### PR TITLE
Gallery rearrangement

### DIFF
--- a/doc/_themes/flask/layout.html
+++ b/doc/_themes/flask/layout.html
@@ -20,7 +20,7 @@
           <a href="{{ pathto("installing") }}">Install</a>
         </li>
         <li>
-          <a class="" href="{{ pathto("pyclaw/gallery/gallery_all") }}">Gallery</a>
+          <a class="" href="{{ pathto("galleries") }}">Gallery</a>
         </li>
         <li>
           <a class="active" href="https://groups.google.com/forum/#!forum/claw-users">Support</a>

--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -56,9 +56,7 @@ Examples and Applications:
    :maxdepth: 1
    
 
-   gallery/gallery_all
-   gallery/gallery_fvmbook
-   gallery/gallery_geoclaw
+   galleries
    book
    newapp
    sharing

--- a/doc/gallery/gallery.py
+++ b/doc/gallery/gallery.py
@@ -354,16 +354,18 @@ def make_fvmbook():
     gallery.create('gallery_fvmbook.rst')
     return gallery
 
-def make_all():
+def make_classic_amrclaw():
     gallery_1d = make_1d()
     gallery_2d = make_2d()
 
     # make gallery of everything:
-    gallery_all = Gallery(title="Gallery of all Clawpack applications")
-    gallery_all.sections = gallery_1d.sections + gallery_2d.sections 
-    #gallery_all.sections = gallery_2d.sections 
+    gallery_classic_amrclaw = Gallery(title="Gallery of Classic and AMRClaw applications")
+    gallery_classic_amrclaw.sections = gallery_1d.sections + gallery_2d.sections 
+    #gallery_classic_amrclaw.sections = gallery_2d.sections 
     
-    gallery_all.create('gallery_all.rst')
+    gallery_classic_amrclaw.create('gallery_classic_amrclaw.rst')
 
 if __name__ == "__main__":
-    make_all()
+    make_classic_amrclaw()
+    make_geoclaw()
+    make_fvmbook()

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -4,6 +4,7 @@
 Installation instructions
 **************************************
 
+See also: :ref:`pyclaw`
 
 
 Prerequisites

--- a/doc/pyclaw/gallery/gallery.py
+++ b/doc/pyclaw/gallery/gallery.py
@@ -81,14 +81,21 @@ class Gallery(object):
 
         gfile = open(fname, 'w')
         gfile.write(":group: pyclaw\n\n")
-        gfile.write(".. _gallery:\n\n")
-        gfile.write("==========================\n")
-        gfile.write("Application gallery\n")
-        gfile.write("==========================\n")
+        #gfile.write(".. _gallery:\n\n")
+        #gfile.write("==============================\n")
+        #gfile.write("Gallery of PyClaw applications\n")
+        #gfile.write("==============================\n")
+
+        gfile.write(".. _%s:\n\n" % os.path.splitext(fname)[0])
+        nchar = len(self.title)
+        gfile.write(nchar*"=" + "\n")
+        gfile.write("%s\n"  % self.title)
+        gfile.write(nchar*"=" + "\n")
+
         gfile.write(".. contents::\n\n")
 
-        gfile.write("%s\n" % self.title)
-        gfile.write("="*len(self.title)+"\n\n")
+        #gfile.write("%s\n" % self.title)
+        #gfile.write("="*len(self.title)+"\n\n")
         for gsec in self.sections:
             gfile.write("%s\n" % gsec.title)
             gfile.write("="*len(gsec.title)+"\n")


### PR DESCRIPTION
changed Gallery link at top of pages and added page galleries.rst with links to all galleries, 

Plus modification of pyclaw title.  

Could not build all the pyclaw examples and pyclaw gallery links to README and _plots are broken.  I think they were previously too.

I made some changes to gallery.py previously when adapting it from doc/pyclaw/gallery to doc/gallery and the other apps have links that work (classic, amrclaw, geoclaw).  Similar changes may be needed in the pyclaw version.
