### PR TITLE
changes to index and layout

### DIFF
--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -26,9 +26,18 @@ Solution of a given PDE system with Clawpack relies on an approximate Riemann so
 that system.  Solvers for many common applications are available in the Riemann package.
 {%endtrans%} </p>
 
-<h2 style="margin-bottom: 0">{%trans%}Packages{%endtrans%}</h2>
+<h2 style="margin-bottom: 0">{%trans%}Documentation{%endtrans%}</h2>
 
   <table class="contentstable" align="center" style="margin-left: 30px"><tr>
+    <td width="50%">
+
+      <p><a class="biglink" href="{{ pathto("contents") }}">{%trans%}Contents{%endtrans%}</a><br/>
+         <span class="linkdescr">{%trans%}for a complete overview{%endtrans%}</span></p>      
+    </td>
+    <td width="50%">
+      <p class="biglink"><a class="biglink" href="{{ pathto("genindex") }}">{%trans%}General Index{%endtrans%}</a><br/>
+         <span class="linkdescr">{%trans%}all functions, classes, terms{%endtrans%}</span></p>
+    </td></tr>
     <td width="50%">
       <p class="biglink"><a class="biglink" href="{{ pathto("amrclaw") }}">{%trans%}AMRClaw{%endtrans%}</a><br/>
          <span class="linkdescr">{%trans%}Adaptive mesh refinement{%endtrans%}</span></p>
@@ -47,28 +56,22 @@ that system.  Solvers for many common applications are available in the Riemann 
 
   <table class="contentstable" align="center" style="margin-left: 30px"><tr>
     <td width="50%">
-      <p class="biglink"><a class="biglink" href="{{ pathto("apps") }}">{%trans%}Applications gallery -- Clawpack{%endtrans%}</a><br/>
-         <span class="linkdescr">{%trans%}Examples of Clawpack simulation results{%endtrans%}</span></p>
-    </td>
-    <td width="50%">
-      <p class="biglink"><a class="biglink" href="{{ pathto("pyclaw/gallery/gallery_all") }}">{%trans%}Applications gallery -- PyClaw{%endtrans%}</a><br/>
-         <span class="linkdescr">{%trans%}Examples of PyClaw simulation results{%endtrans%}</span></p>
+      <p class="biglink"><a class="biglink" href="{{ pathto("galleries") }}">{%trans%}Applications gallery {%endtrans%}</a><br/>
+         <span class="linkdescr">{%trans%}Examples of Clawpack, PyClaw,
+AMRClaw, and GeoClaw simulation results{%endtrans%}</span></p>
     </td></tr>
   </table>
 
-
-<h2 style="margin-bottom: 0">{%trans%}Site map{%endtrans%}</h2>
+<h2 style="margin-bottom: 0">{%trans%}Older versions{%endtrans%}</h2>
 
   <table class="contentstable" align="center" style="margin-left: 30px"><tr>
     <td width="50%">
-
-      <p><a class="biglink" href="{{ pathto("contents") }}">{%trans%}Contents{%endtrans%}</a><br/>
-         <span class="linkdescr">{%trans%}for a complete overview{%endtrans%}</span></p>      
+      <p class="biglink"><a class="biglink"
+href="http://www.clawpack.org">{%trans%}Clawpack 4.x home page{%endtrans%}</a><br/>
+         <span class="linkdescr">{%trans%}with links to documentation and
+downloads{%endtrans%}</span></p>
     </td>
-    <td width="50%">
-      <p class="biglink"><a class="biglink" href="{{ pathto("genindex") }}">{%trans%}General Index{%endtrans%}</a><br/>
-         <span class="linkdescr">{%trans%}all functions, classes, terms{%endtrans%}</span></p>
-    </td></tr>
+    </tr>
   </table>
 
 

--- a/doc/_themes/flask/layout.html
+++ b/doc/_themes/flask/layout.html
@@ -10,11 +10,12 @@
 <div id="main-wrapper" class="sphinx">
 <div id="header-wrapper">
   <section id="header">
-    <h1><a href="http://clawpack.org/">Clawpack</a></h1>
+    <!-- <h1><a href="http://clawpack.org/">Clawpack</a></h1> -->
+    <h1><a href="{{ pathto("index") }}">Clawpack</a></h1> 
     <nav>
       <ul>
         <li>
-          <a href="{{ pathto("index") }}">Docs</a>
+          <a href="{{ pathto("toc_condensed") }}">Docs</a>
         </li>
         <li>
           <a href="{{ pathto("installing") }}">Install</a>


### PR DESCRIPTION
I modified the main page that shows up at
  http://clawpack.github.io/doc/index.html

(eventually www.clawpack.org will point to this page?)

Also changed where some of the links on the top menu point, and added a condensed table of contents (in PR #22).

Clawpack points to index
Docs points to condensed toc.

Does this look ok for now?
