### PR TITLE
Fix path to clawlogo file.

### DIFF
--- a/doc/_themes/flask/sidelogo.html
+++ b/doc/_themes/flask/sidelogo.html
@@ -1,5 +1,5 @@
 <p><a href="index.html">
-  <img class="logo" src= "/_static/clawlogo.jpg" alt="Logo"/>
+  <img class="logo" src= "/doc/_static/clawlogo.jpg" alt="Logo"/>
 </a>
 <h2>Version {{ release }}</h2>
 </p>


### PR DESCRIPTION
When I introduced the file sidelogo.html, to make the logo link to index.html instead of to contents.html, I used a relative path, which caused the logo not to appear for pages that are not in the base directory of the docs.

In a recent commit, I tried to fix this by using a root-relative path, but I gave the wrong path.  This commit should fix it so the logo appears on all pages on clawpack.github.io, but unfortunately it does not fix it for viewing the pages locally.  I haven't figured out how to make both work.
