### PR TITLE
Specify logo location correctly using asset_root.

### DIFF
--- a/doc/_themes/flask/layout.html
+++ b/doc/_themes/flask/layout.html
@@ -5,6 +5,13 @@
 
 {%- block relbar2 %}{% endblock %}
 
+{%- block sidebarlogo %}
+<p><a href="index.html">
+    <img class="logo" src= "{{ asset_root }}/clawlogo.jpg" alt="Logo"/>
+</a>
+<h2>Version {{ release }}</h2>
+</p>
+{%- endblock %}
 
 {%- block header %}
 <div id="main-wrapper" class="sphinx">

--- a/doc/_themes/flask/sidelogo.html
+++ b/doc/_themes/flask/sidelogo.html
@@ -1,5 +1,0 @@
-<p><a href="index.html">
-  <img class="logo" src= "/doc/_static/clawlogo.jpg" alt="Logo"/>
-</a>
-<h2>Version {{ release }}</h2>
-</p>

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -117,8 +117,8 @@ html_additional_pages = {'index': 'index.html'}
 
 # Custom sidebar templates, maps document names to template names.
 html_sidebars = {
-    'index':    ['sidelogo.html', 'localtoc.html', 'sourcelink.html', 'searchbox.html'],
-    '**':       ['sidelogo.html', 'localtoc.html', 'relations.html',
+    'index':    ['localtoc.html', 'sourcelink.html', 'searchbox.html'],
+    '**':       ['localtoc.html', 'relations.html',
                  'sourcelink.html', 'searchbox.html']
 }
 


### PR DESCRIPTION
This is an update to https://github.com/clawpack/doc/pull/36.  I've finally found (I think) the proper way to do this by overriding the "sidebarlogo" block in layout.html and using the asset_root variable to specify the logo location.
