### PR TITLE
Make PyClaw examples paths work for non-dev installs, too.

### DIFF
--- a/doc/pyclaw/gallery/gallery.py
+++ b/doc/pyclaw/gallery/gallery.py
@@ -16,7 +16,7 @@ claw_html_root='..'
 
 # Determine PyClaw directory:
 from clawpack import pyclaw
-clawdir_default = os.path.join('/'.join(pyclaw.__path__[0].split('/')[:-2])+'/')
+clawdir_default = os.path.join('/'.join(pyclaw.__path__[0].split('/')[:-1])+'/')
 
 # Location for gallery files:
 gallery_dir_default = '.'#os.path.join(clawdir_default,'doc/gallery')  

--- a/doc/pyclaw/gallery/how-to-build.rst
+++ b/doc/pyclaw/gallery/how-to-build.rst
@@ -1,0 +1,23 @@
+.. _build-gallery:
+
+Building the PyClaw gallery locally
+===================================
+
+You can build a local copy of the PyClaw gallery as follows: first, you should clone
+the clawpack documentation repository::
+
+    git clone git://github.com/clawpack/doc
+
+Then run all the examples::
+
+    cd doc/doc/pyclaw/gallery
+    python gallery.py
+
+Next generate the gallery itself::
+
+    python gallery.py
+
+Finally, you need to call sphinx to convert all the .rst files to .html::
+
+    cd ../..
+    make html

--- a/doc/pyclaw/gallery/make_plots.py
+++ b/doc/pyclaw/gallery/make_plots.py
@@ -13,7 +13,7 @@ def list_examples(examples_dir=None):
 
     if examples_dir is None:
         from clawpack import pyclaw
-        examples_dir = '/'.join(pyclaw.__path__[0].split('/')[:-2])+'/pyclaw/examples/'
+        examples_dir = pyclaw.__path__[0]+'/examples'
 
     examples_dir = os.path.abspath(examples_dir)
     current_dir = os.getcwd()
@@ -68,9 +68,8 @@ def make_plots(examples_dir = None):
 
     if examples_dir is None:
         from clawpack import pyclaw
-        examples_dir = '/'.join(pyclaw.__path__[0].split('/')[:-2])+'/pyclaw/examples/'
+        examples_dir = pyclaw.__path__[0]+'/examples'
 
-    print examples_dir
     examples_dir = os.path.abspath(examples_dir)
     current_dir = os.getcwd()
  
@@ -143,4 +142,9 @@ def make_plots(examples_dir = None):
     os.chdir(current_dir)
 
 if __name__=='__main__':
-    make_plots()
+    import sys
+    if len(sys.argv)>1:
+        print sys.argv
+        make_plots(sys.argv[1])
+    else:
+        make_plots()

--- a/doc/pyclaw/index.rst
+++ b/doc/pyclaw/index.rst
@@ -50,6 +50,7 @@ PyClaw Documentation
    about
    future
    gallery/gallery_all
+   gallery/how-to-build
 
 
 .. _pyclaw_reference:


### PR DESCRIPTION
Fixes https://github.com/clawpack/pyclaw/issues/350 by using the full path (rather than trying to strip out the symlink level in a dev install).
