### PR TITLE
Outline of a paper on Clawpack 5.x

### DIFF
--- a/papers/Clawpack5x.md
+++ b/papers/Clawpack5x.md
@@ -1,0 +1,55 @@
+
+# The Clawpack 5.x Software
+
+Authors: Anyone who has....
+* Made a nontrivial contribution to 5.0, 5.1, 5.2,
+* Contributes at least a sentence to the paper,
+* Has read the final draft and agreed to be an author.
+
+## Github organization, subrepositories
+
+## Development model
+    * forks, master, branches, pull requests
+    * travis
+
+## Global changes
+    * reordering indices
+    * input variables in setrun.py (discuss Python interface to Fortran)
+
+## riemann repository -- used by PyClaw via f2py
+
+## classic: 
+    * added 3d with OpenMP
+
+## amrclaw: 
+    * added 3d with OpenMP, 
+    * added regions
+    * other changes motivated by Geoclaw
+
+## geoclaw: 
+    * NTHMP benchmarks
+    * setaux copying for faster topography integration, recursive 
+    * new topotools and dtopotools
+    * multiple dtopo files
+    * fixed grid monitoring of max values
+
+## pyclaw:
+    * overall structure/languages figure
+    * sharpclaw
+    * petclaw
+    * f2py
+    * pip install
+    * IPython notebooks
+
+## visclaw:
+    * Iplotclaw
+    * creation of html pages
+    * JSAnimation
+    * (Once 3d is working, write a separate paper on visclaw as a general tool?)
+
+## future plans:
+    * Clawpack 6 ideas
+    * Riemann solvers
+    * ForestClaw
+    * ???
+


### PR DESCRIPTION
It would be good to publish a brief paper outlining changes to Clawpack from 4.x to 5.x, as a possible suggested citation for users of Clawpack.

Motivated by discussions on how to cite software at PDESoft 2014, see also 
  https://github.com/uwescience/citing_software

We can at least post this paper on arXiv, possibly submit to ??.
