### PR TITLE
Update shallow water example name and fix gallery build instructions.

### DIFF
--- a/doc/pyclaw/gallery/gallery.py
+++ b/doc/pyclaw/gallery/gallery.py
@@ -255,7 +255,7 @@ def make_1d():
     #----------------------------------------------
     gsec = gallery.new_section("1-dimensional shallow water equation")
     appdir = 'pyclaw/examples/shallow_1d'
-    appname = 'shallow_water_shocktube'
+    appname = 'dam_break'
     description = """Shallow water shock tube."""
     images = ('frame0000fig0', 'frame0003fig0', 'frame0006fig0')
     gsec.new_item(appdir, appname, plotdir, description, images)

--- a/doc/pyclaw/gallery/how-to-build.rst
+++ b/doc/pyclaw/gallery/how-to-build.rst
@@ -11,7 +11,7 @@ the clawpack documentation repository::
 Then run all the examples::
 
     cd doc/doc/pyclaw/gallery
-    python gallery.py
+    python make_plots.py
 
 Next generate the gallery itself::
 


### PR DESCRIPTION
Fixes https://github.com/clawpack/clawpack.github.com/issues/3.  An example was renamed in PyClaw and this needed to be updated here.  Also, add a missing step in the gallery build instructions.
