### PR TITLE
Add pdf version of the documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -209,17 +209,17 @@ htmlhelp_basename = 'Clawpackdoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, document class [howto/manual]).
 latex_documents = [
-  ('index', 'Clawpack.tex', ur'Clawpack Documentation',
-   ur'RJL', 'manual'),
+  ('contents', 'ClawpackDocs30Nov2014.tex', ur'Clawpack Documentation',
+   ur'The Clawpack Development Team', 'manual', False),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
-#latex_logo = None
+latex_logo =  '_static/clawlogo.jpg'
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
-#latex_use_parts = False
+latex_use_parts = True
 
 # Additional stuff for the LaTeX preamble.
 #latex_preamble = ''
@@ -228,7 +228,10 @@ latex_documents = [
 #latex_appendices = []
 
 # If false, no module index is generated.
-#latex_use_modindex = True
+latex_use_modindex = True
+
+latex_show_pagerefs = True
+latex_show_urls = 'inline'
 
 
 # Example configuration for intersphinx: refer to the Python standard library.

--- a/doc/extra_files/pdf/index.html
+++ b/doc/extra_files/pdf/index.html
@@ -1,0 +1,30 @@
+ 
+<html>
+   
+<title>Clawpack Documentation -- pdf files</title>
+
+<body TEXT="#000000" BGCOLOR="#FFFFE8" LINK="#7F0000" VLINK="#7F0000">
+<font FACE="HELVETICA,ARIAL">
+
+<center> 
+<a href="http://www.clawpack.org">
+   <IMG SRC="../clawlogo.jpg" WIDTH="200" HEIGHT="70" VSPACE="0"
+HSPACE="0"
+ ALT="CLAWPACK" BORDER="0" LOOP="0"> </a>
+</center>
+<h1>Clawpack Documentation -- pdf files</h1>
+
+These pdf files should mirror what was available at 
+<a href="http://www.clawpack.org">clawpack.org</a> on the date indicated.
+<p>
+<b>Note:</b> Needs some work, not everything turned out so well...
+<ul>
+<li> Clawpack 5.2.2 Documentation:
+    <ul>
+    <li> <a href="ClawpackDocs30Nov2014.pdf">ClawpackDocs30Nov2014.pdf</a>
+    </ul>
+</ul>
+
+
+</html>
+

--- a/doc/git_links.inc
+++ b/doc/git_links.inc
@@ -1,0 +1,61 @@
+.. This (-*- rst -*-) format file contains commonly used link targets
+   and name substitutions.  It may be included in many files,
+   therefore it should only contain link targets and name
+   substitutions.  Try grepping for "^\.\. _" to find plausible
+   candidates for this list.
+
+.. NOTE: reST targets are
+   __not_case_sensitive__, so only one target definition is needed for
+   nipy, NIPY, Nipy, etc...
+
+.. git stuff
+.. _git: http://git-scm.com/
+.. _github: http://github.com
+.. _github help: http://help.github.com
+.. _msysgit: http://code.google.com/p/msysgit/downloads/list
+.. _git-osx-installer: http://code.google.com/p/git-osx-installer/downloads/list
+.. _subversion: http://subversion.tigris.org/
+.. _git cheat sheet: http://github.com/guides/git-cheat-sheet
+.. _pro git book: http://progit.org/
+.. _git svn crash course: http://git-scm.com/course/svn.html
+.. _learn.github: http://learn.github.com/
+.. _network graph visualizer: http://github.com/blog/39-say-hello-to-the-network-graph-visualizer
+.. _git user manual: http://www.kernel.org/pub/software/scm/git/docs/user-manual.html
+.. _git tutorial: http://www.kernel.org/pub/software/scm/git/docs/gittutorial.html
+.. _git community book: http://book.git-scm.com/
+.. _git ready: http://www.gitready.com/
+.. _git casts: http://www.gitcasts.com/
+.. _Fernando's git page: http://www.fperez.org/py4science/git.html
+.. _git magic: http://www-cs-students.stanford.edu/~blynn/gitmagic/index.html
+.. _git concepts: http://www.eecs.harvard.edu/~cduan/technical/git/
+.. _git clone: http://www.kernel.org/pub/software/scm/git/docs/git-clone.html
+.. _git checkout: http://www.kernel.org/pub/software/scm/git/docs/git-checkout.html
+.. _git commit: http://www.kernel.org/pub/software/scm/git/docs/git-commit.html
+.. _git push: http://www.kernel.org/pub/software/scm/git/docs/git-push.html
+.. _git pull: http://www.kernel.org/pub/software/scm/git/docs/git-pull.html
+.. _git add: http://www.kernel.org/pub/software/scm/git/docs/git-add.html
+.. _git status: http://www.kernel.org/pub/software/scm/git/docs/git-status.html
+.. _git diff: http://www.kernel.org/pub/software/scm/git/docs/git-diff.html
+.. _git log: http://www.kernel.org/pub/software/scm/git/docs/git-log.html
+.. _git branch: http://www.kernel.org/pub/software/scm/git/docs/git-branch.html
+.. _git remote: http://www.kernel.org/pub/software/scm/git/docs/git-remote.html
+.. _git rebase: http://www.kernel.org/pub/software/scm/git/docs/git-rebase.html
+.. _git config: http://www.kernel.org/pub/software/scm/git/docs/git-config.html
+.. _why the -a flag?: http://www.gitready.com/beginner/2009/01/18/the-staging-area.html
+.. _git staging area: http://www.gitready.com/beginner/2009/01/18/the-staging-area.html
+.. _tangled working copy problem: http://tomayko.com/writings/the-thing-about-git 
+.. _git management: http://kerneltrap.org/Linux/Git_Management
+.. _linux git workflow: http://www.mail-archive.com/dri-devel@lists.sourceforge.net/msg39091.html
+.. _git parable: http://tom.preston-werner.com/2009/05/19/the-git-parable.html
+.. _git foundation: http://matthew-brett.github.com/pydagogue/foundation.html
+.. _deleting master on github: http://matthew-brett.github.com/pydagogue/gh_delete_master.html
+.. _rebase without tears: http://matthew-brett.github.com/pydagogue/rebase_without_tears.html
+.. _resolving a merge: http://www.kernel.org/pub/software/scm/git/docs/user-manual.html#resolving-a-merge
+.. _ipython git workflow: http://mail.scipy.org/pipermail/ipython-dev/2010-October/006746.html
+
+.. other stuff
+.. _python: http://www.python.org
+
+.. |emdash| unicode:: U+02014
+
+.. vim: ft=rst


### PR DESCRIPTION
To create the pdf:

```
    cd $CLAW/doc/doc
    make latex
    cd _build/latex
    make
    # then type q when it starts throwing errors that need to be fixed
    pdflatex ClawpackDocs30Nov2014
```

The last step seems needed to make the TOC properly.

Problems:
- Lots of math errors are thrown.
- Various things should probably be omitted, e.g. gallery?
