### PR TITLE
Fix broken github links: "organizations"->"orgs".

### DIFF
--- a/doc/_themes/flask/layout.html
+++ b/doc/_themes/flask/layout.html
@@ -34,7 +34,7 @@
           <a class="" href="{{ pathto("community") }}">Community</a>
         </li>
         <li>
-          <a class="active" href="http://github.com/organizations/clawpack">Source</a>
+          <a class="active" href="http://github.com/clawpack">Source</a>
         </li>
         <li>
           <a class="" href="{{ pathto("developers") }}">Develop</a>

--- a/doc/clawpack5.rst
+++ b/doc/clawpack5.rst
@@ -33,13 +33,13 @@ to 4.6 form using :ref:`claw43to46`.
 If you wish to view recent changes on GitHub,
 note that Clawpack is an *organization*, meaning that it is
 comprised of several repositories.  Go to the 
-`Clawpack GitHub <https://github.com/organizations/clawpack>`_ 
+`Clawpack GitHub <https://github.com/clawpack>`_ 
 webpage to view all the repositories.  Major changes that are specific
 to PyClaw since its initial release in 2012 are listed in the
 `PyClaw changelog <https://github.com/clawpack/pyclaw/blob/master/CHANGES.md>`_.
 
 You might also view the 
-`issues <https://github.com/organizations/clawpack/dashboard/issues>`_
+`issues <https://github.com/orgs/clawpack/dashboard/issues>`_
 associated with each Clawpack repository on
 GitHub to see what bugs and features we are working on.
 

--- a/doc/clawpack_components.rst
+++ b/doc/clawpack_components.rst
@@ -8,7 +8,7 @@ Clawpack components
 
 Clawpack is developed using the `git <http://git-scm.com/>`_ version control
 system and all the source code is openly available via the
-`Clawpack GitHub Organization <https://github.com/organizations/clawpack>`_.
+`Clawpack GitHub Organization <https://github.com/orgs/clawpack>`_.
 
 The code is organized in several independent git repositories.  One of these
 is the `clawpack/clawpack <https://github.com/clawpack/clawpack>`_
@@ -36,7 +36,7 @@ Other repositories
 -----------------------
 
 Other repositories in the
-`Clawpack GitHub Organization <https://github.com/organizations/clawpack>`_
+`Clawpack GitHub Organization <https://github.com/orgs/clawpack>`_
 may be of interest to some users:
 
 * `apps` contains additional applications, see :ref:`apps`.

--- a/doc/extra_files/clawdev2013/index.html
+++ b/doc/extra_files/clawdev2013/index.html
@@ -192,7 +192,7 @@ You can also post slides for your lightning talks there.
 <li> <a href="http://www.clawpack.org">Main Clawpack page</a> with links to
 other projects.
 <p>
-<li><a href="https://github.com/organizations/clawpack">Github repositories</a>
+<li><a href="https://github.com/orgs/clawpack">Github repositories</a>
 ...
 <a href="http://clawpack.github.io/doc/git_and_github.html">Suggested
 git workflow</a>
@@ -206,8 +206,8 @@ construction, primarily amrclaw, geoclaw, visclaw.) ...
 <li> Many conversations regarding Clawpack development
 take place on the <a href="http://groups.google.com/group/claw-dev">claw-dev</a>
 google group as well as in the Github 
-<a href="https://github.com/organizations/clawpack/dashboard/issues">issues</a> and 
-<a href="https://github.com/organizations/clawpack/dashboard/pulls">pull
+<a href="https://github.com/orgs/clawpack/dashboard/issues">issues</a> and 
+<a href="https://github.com/orgs/clawpack/dashboard/pulls">pull
 requests</a>.
 
 </ul>

--- a/doc/links.inc
+++ b/doc/links.inc
@@ -9,7 +9,7 @@
    nipy, NIPY, Nipy, etc...
 
 .. clawpack stuff
-.. _Clawpack GitHub: https://github.com/organizations/clawpack
+.. _Clawpack GitHub: https://github.com/orgs/clawpack
 
 .. other stuff
 .. _python: http://www.python.org


### PR DESCRIPTION
Fixes https://github.com/clawpack/clawpack.github.com/issues/7.