### PR TITLE
WIP: updated installing.rst and various files it points to. 

### DIFF
--- a/doc/about.rst
+++ b/doc/about.rst
@@ -111,9 +111,16 @@ If you use Clawpack in publications, please cite the following::
         author={{Clawpack Development Team}}, 
         url={http://www.clawpack.org}, 
         note={Version x.y},
+        doi={10.5281/zenodo.50982},
         year={2014}}
 
 Please fill in the version number that you used, and its year.
+
+For recent releases you can also include a DOI from 
+`Zenodo <https://zenodo.org>`_ , for example
+
+    * Version 5.3.1: `10.5281/zenodo.50982 <http://dx.doi.org/10.5281/zenodo.50982>`_
+
 
 Please also cite at least one of the following regarding the algorithms used
 in Clawpack (click the links for bibtex citations):

--- a/doc/first_run_fortran.rst
+++ b/doc/first_run_fortran.rst
@@ -1,26 +1,44 @@
-.. _first_run:
+.. _first_run_fortran:
+
+Testing your Fortran installation and running an example
+=============================================================
+
+This assumes that you have downloaded the Fortran components of Clawpack,
+see :ref:`install_fortran`.
+
+First ensure that you have :ref:`setenv`
+and that you have the :ref:`install_prerequisites`.
+
+As a first test of the Fortran code, try the following::
+
+    cd $CLAW/classic/tests
+    nosetests -sv
+
+This will run several tests and compare a few numbers from the solution with
+archived results.  The tests should run in a few seconds and 
+you should see output similar to this::
+
+    runTest (tests.acoustics_1d_heterogeneous.regression_tests.Acoustics1DHeterogeneousTest) ... ok
+    runTest (tests.acoustics_3d_heterogeneous.regression_tests.Acoustics3DHeterogeneousTest) ... ok
+    runTest (tests.advection_2d_annulus.regression_tests.Advection2DAnnulusTest) ... ok
+
+    ----------------------------------------------------------------------
+    Ran 3 tests in 4.639s
+    OK
+
+
+There are similar `tests` subdirectories of `$CLAW/amrclaw` and
+`$CLAW/geoclaw` to do quick tests of these codes.
+
 
 Running an example
-==================
+------------------
 
 Many examples of Clawpack simulations can be seen in the :ref:`galleries`.
 
-See also :ref:`first_tests`.
-
-PyClaw
-------
-To run an example and plot the results using PyClaw, simply do the following
-(starting from your `clawpack` directory)::
-
-    cd pyclaw/examples/euler_2d
-    python shock_bubble_interaction.py iplot=1
-
-That's it.  For next steps with PyClaw, see :ref:`basics`.
 
 Classic
 -------
-First ensure that you have :ref:`setenv`
-and that you have the :ref:`install_prerequisites`.
 
 A simple 1-dimensional acoustics equations can be solved
 using the code in `$CLAW/classic/examples/acoustics_1d_example1
@@ -113,4 +131,14 @@ Other visualization packages could also be used to display the results, but you 
 to figure out how to read in the data.  See :ref:`fortfiles` for information about the
 format of the files produced by Clawpack.
 
+More examples
+-------------
 
+There are additional examples in these directories:
+
+    * `$CLAW/classic/examples`
+    * `$CLAW/amrclaw/examples`
+    * `$CLAW/geoclaw/examples`
+
+You might also want to download the :ref:`apps`, which contains additional
+examples.

--- a/doc/first_run_pyclaw.rst
+++ b/doc/first_run_pyclaw.rst
@@ -1,0 +1,33 @@
+.. _first_run_pyclaw:
+
+Testing a PyClaw installation and running an example
+=====================================================
+
+If you downloaded Clawpack manually, you can test your :ref:`pyclaw`
+installation as follows (starting from your `clawpack` directory)::
+
+    cd pyclaw
+    nosetests
+
+This should return 'OK'.
+
+
+Running an example
+------------------
+
+Many examples of Clawpack simulations can be seen in the :ref:`galleries`.
+
+To run an example and plot the results using PyClaw, simply do the following
+(starting from your `clawpack` directory)::
+
+    cd pyclaw/examples/euler_2d
+    python shock_bubble_interaction.py iplot=1
+
+That's it.  For next steps with PyClaw, see :ref:`basics`.
+
+More examples
+-------------
+
+You might also want to download the :ref:`apps`, which contains additional
+examples.
+

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -4,6 +4,8 @@
 Installation instructions
 **************************************
 
+To replace :ref:`installing_old`.
+
 .. contents::
    :depth: 2
 
@@ -16,32 +18,49 @@ Note that any of these installations also includes :ref:`visclaw` for plotting.
 
 See also:
 
-* :ref:`trouble_installation`
+* :ref:`install_prerequisites`
 * :ref:`clawpack_packages`
+* :ref:`changes`
+* :ref:`previous`
+* :ref:`trouble_installation`
 
 .. _install_pyclaw:
 
 Install only PyClaw (serial)
 =====================================
-If you wish to install just PyClaw, everything is handled by pip::
+
+This works if you only wish to use the :ref:`pyclaw` Python interface 
+(but **not** run Fortran codes from the Classic, :ref:`amrclaw`,
+or :ref:`geoclaw` portions of Clawpack).  For more information, see
+:ref:`clawpack_packages`
+
+If you wish to install just PyClaw, everything can be handled by pip::
 
     pip install clawpack
 
-Next go to :ref:`first_run`.
+Next go to :ref:`first_run_pyclaw`.
 
 
+.. _install_fortran:
 
-.. _install_clawpack:
+Install Fortran packages and Python tools
+==========================================
 
-Install all Clawpack packages
-=====================================
+This works if you wish to use the 
+Fortran codes from the Classic, :ref:`amrclaw`, or :ref:`geoclaw` portions of
+Clawpack, and the associated Python
+tools (as needed for specifying input in `setrun.py`, plotting results with
+`setplot.py` and :ref:`visclaw`, etc.)
+
 First, download a tar file of the latest release:
 
 * `https://github.com/clawpack/clawpack/releases/download/v5.3.1/clawpack-5.3.1.tar.gz
   <https://github.com/clawpack/clawpack/releases/download/v5.3.1/clawpack-5.3.1.tar.gz>`_
-* :ref:`previous`
-* :ref:`changes`
 
+Alternatively, tarfiles for releases are also archived on 
+`Zenodo <https://zenodo.org>`_ with
+permanent DOIs.  The most recent release can be found at:
+`10.5281/zenodo.50982 <http://dx.doi.org/10.5281/zenodo.50982>`_
 
 See :ref:`clawpack_components` for a list of what's included in this tar file.
 
@@ -54,32 +73,23 @@ clawpack tree to reside.  Then untar using the command::
 Then move into the top level directory::
 
     cd clawpack-5.3.1
+    pwd
 
-Next install the Python components of Clawpack::
-
-    python setup.py install
-
-This will compile a lot of Fortran code using `f2py` and will produce a lot of 
-output, so you might want to redirect the output, e.g. ::
-
-    python setup.py install > install_output.txt
-
-If you get compilation errors in this step, you can still use the
-Classic, AMRClaw, and GeoClaw; see :ref:`install_no-pyclaw`.
-
-If you only plan to use PyClaw, jump to :ref:`first_run`.  If you
-plan to use Classic, AMRClaw, or GeoClaw continue with :ref:`setenv`.
+The `pwd` command should print the `/full/path/to/top/level` that you
+will need in the next step
 
 .. _setenv:
 
 Set environment variables
 -------------------------
+
 To use the Fortran versions of Clawpack you will need to set the
 environment variable `CLAW` to point to the top level of clawpack tree
-(there is no need to perform this step if you will only use PyClaw).
+and adjust your `PYTHONPATH` to include the same directory.
 In the bash shell these can be set via::
 
     export CLAW=/full/path/to/top/level
+    export PYTHONPATH=$CLAW:$PYTHONPATH
 
 You also need to set `FC` to point to the desired Fortran compiler,
 e.g.::
@@ -97,53 +107,66 @@ If your environment variable `CLAW` is properly set, the command ::
 
 should list the top level directory, and report for example::
 
-    README.md       riemann/        pyclaw/
-    amrclaw/        setup.py        clawutil/       
-    geoclaw/        visclaw/        classic/        
+    CITATION.md changes.md  clawutil/   riemann/
+    README.md   classic/    geoclaw/    setup.py
+    amrclaw/    clawpack/   pyclaw/     visclaw/
+
  
-Next go to :ref:`first_run`.
+.. _install_symlink:
 
-
-.. _install_no-pyclaw:
-
-Install other packages without compiling PyClaw
-================================================
-If you get errors in the compilation step when using `pip install` or
-`python setup.py install`, check :ref:`trouble_installation`. 
-If your problem is not addressed there, please `let us know <claw-users@googlegroups.com>`_
-or `raise an issue <https://github.com/clawpack/clawpack/issues>`_.
-You can still use the Fortran codes (AMRClaw, GeoClaw, and Classic) by doing
-the following.  
-
-First, download a tarfile of the latest release as described in
-:ref:`install_clawpack`.  
-
-Next :ref:`setenv`.  You must then also set your PYTHONPATH manually::
-
-    export PYTHONPATH=$CLAW:$PYTHONPATH
+Create symbolic links
+---------------------
 
 Then you should be able to do::
 
     cd $CLAW   # assuming this environment variable was properly set
     python setup.py symlink-only
 
-This will create some symbolic links in the `$CLAW/clawpack` 
-subdirectory of your top level Clawpack directory, but does not compile code
-or put anything in your site-packages.
-In Python you should now be able to do the following, for example::
+This last step creates some symbolic links (in the directory
+`$CLAW/clawpack`) that are needed in order for import
+statements to work properly in Python.  You should now be able to start a
+Python (or IPython) shell (from any directory)
+and do the following command, for example, with no error:
 
     >>> from clawpack import visclaw
 
 If not then either your `$PYTHONPATH` environment variable is not set
-properly or the required symbolic links were not created.
+properly, or the required symbolic links were not created.
 
-Next go to :ref:`first_run`.
+Next go to :ref:`first_run_fortran`.
+
+
+
+.. _install_fortran_pyclaw:
+
+Install for using both Fortran and PyClaw components
+=====================================================
+
+If you have installed using the procedure just described to 
+:ref:`install_fortran` and you also want to use :ref:`pyclaw` (to run Clawpack
+solvers directly from Python), then you can add one more step::
+
+    cd $CLAW
+    python setup.py install
+
+This will compile a lot of Fortran code using `f2py` and will produce a lot of 
+output, so you might want to redirect the output, e.g. ::
+
+    python setup.py install > install_output.txt
+
+If you get compilation errors in this step, you can still use the
+Fortran codes (and associated Python tools) without problems.
+
+To experiment with :ref:`pyclaw`, jump to :ref:`first_run_pyclaw`.  
+
+    >>> from clawpack import visclaw
+
 
 .. _install_pyclaw_parallel:
 
 Install only PyClaw (for running in parallel)
 ================================================
-First, install PyClaw as explained above.  Then see the install instructions
+First, install :ref:`pyclaw` as explained above.  Then see the install instructions
 for :ref:`parallel`.
 
 Alternatively, you may use the following shell scripts (assembled by Damian San Roman)
@@ -211,38 +234,11 @@ some installation options.
 - `NumPy <http://www.numpy.org/>`_  (for PyClaw/VisClaw)
 - `matplotlib <http://matplotlib.org/>`_ (for PyClaw/VisClaw)
 
-See :ref:`python` for information on
+The `Anaconda Python Distribution <https://docs.continuum.io/anaconda/index>`_
+is an easy way to get all of these. 
+See :ref:`python` for more information on
 installing the required modules and to get started using Python if
 you are not familiar with it.
 
   
 
-.. _first_test:
-
-Testing your installation 
-================================================
-
-PyClaw
-------
-If you downloaded Clawpack manually, you can test your PyClaw
-installation as follows (starting from your `clawpack` directory)::
-
-    cd pyclaw
-    nosetests
-
-This should return 'OK'.
-
-Classic
--------
-As a first test of the Fortran code, try the following::
-
-    cd $CLAW/classic/tests
-    make tests
-
-This will run several tests and compare a few numbers from the solution with
-archived results.  The tests should run in a few seconds.
-
-There are similar `tests` subdirectories of `$CLAW/amrclaw` and
-`$CLAW/geoclaw` to do quick tests of these codes.
-
-See also :ref:`testing`.

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -1,10 +1,11 @@
 .. _installing:
 
 **************************************
-Installation instructions
+Installation instructions (original)
 **************************************
 
-To replace :ref:`installing_old`.
+For a simplified approach that is still being tweaked, see
+:ref:`installing_pip`.
 
 .. contents::
    :depth: 2
@@ -18,49 +19,32 @@ Note that any of these installations also includes :ref:`visclaw` for plotting.
 
 See also:
 
-* :ref:`install_prerequisites`
-* :ref:`clawpack_packages`
-* :ref:`changes`
-* :ref:`previous`
 * :ref:`trouble_installation`
+* :ref:`clawpack_packages`
 
 .. _install_pyclaw:
 
 Install only PyClaw (serial)
 =====================================
-
-This works if you only wish to use the :ref:`pyclaw` Python interface 
-(but **not** run Fortran codes from the Classic, :ref:`amrclaw`,
-or :ref:`geoclaw` portions of Clawpack).  For more information, see
-:ref:`clawpack_packages`
-
-If you wish to install just PyClaw, everything can be handled by pip::
+If you wish to install just PyClaw, everything is handled by pip::
 
     pip install clawpack
 
-Next go to :ref:`first_run_pyclaw`.
+Next go to :ref:`first_run`.
 
 
-.. _install_fortran:
 
-Install Fortran packages and Python tools
-==========================================
+.. _install_clawpack:
 
-This works if you wish to use the 
-Fortran codes from the Classic, :ref:`amrclaw`, or :ref:`geoclaw` portions of
-Clawpack, and the associated Python
-tools (as needed for specifying input in `setrun.py`, plotting results with
-`setplot.py` and :ref:`visclaw`, etc.)
-
+Install all Clawpack packages
+=====================================
 First, download a tar file of the latest release:
 
 * `https://github.com/clawpack/clawpack/releases/download/v5.3.1/clawpack-5.3.1.tar.gz
   <https://github.com/clawpack/clawpack/releases/download/v5.3.1/clawpack-5.3.1.tar.gz>`_
+* :ref:`previous`
+* :ref:`changes`
 
-Alternatively, tarfiles for releases are also archived on 
-`Zenodo <https://zenodo.org>`_ with
-permanent DOIs.  The most recent release can be found at:
-`10.5281/zenodo.50982 <http://dx.doi.org/10.5281/zenodo.50982>`_
 
 See :ref:`clawpack_components` for a list of what's included in this tar file.
 
@@ -73,23 +57,32 @@ clawpack tree to reside.  Then untar using the command::
 Then move into the top level directory::
 
     cd clawpack-5.3.1
-    pwd
 
-The `pwd` command should print the `/full/path/to/top/level` that you
-will need in the next step
+Next install the Python components of Clawpack::
+
+    python setup.py install
+
+This will compile a lot of Fortran code using `f2py` and will produce a lot of 
+output, so you might want to redirect the output, e.g. ::
+
+    python setup.py install > install_output.txt
+
+If you get compilation errors in this step, you can still use the
+Classic, AMRClaw, and GeoClaw; see :ref:`install_no-pyclaw`.
+
+If you only plan to use PyClaw, jump to :ref:`first_run`.  If you
+plan to use Classic, AMRClaw, or GeoClaw continue with :ref:`setenv`.
 
 .. _setenv:
 
 Set environment variables
 -------------------------
-
 To use the Fortran versions of Clawpack you will need to set the
 environment variable `CLAW` to point to the top level of clawpack tree
-and adjust your `PYTHONPATH` to include the same directory.
+(there is no need to perform this step if you will only use PyClaw).
 In the bash shell these can be set via::
 
     export CLAW=/full/path/to/top/level
-    export PYTHONPATH=$CLAW:$PYTHONPATH
 
 You also need to set `FC` to point to the desired Fortran compiler,
 e.g.::
@@ -107,66 +100,53 @@ If your environment variable `CLAW` is properly set, the command ::
 
 should list the top level directory, and report for example::
 
-    CITATION.md changes.md  clawutil/   riemann/
-    README.md   classic/    geoclaw/    setup.py
-    amrclaw/    clawpack/   pyclaw/     visclaw/
-
+    README.md       riemann/        pyclaw/
+    amrclaw/        setup.py        clawutil/       
+    geoclaw/        visclaw/        classic/        
  
-.. _install_symlink:
+Next go to :ref:`first_run`.
 
-Create symbolic links
----------------------
+
+.. _install_no-pyclaw:
+
+Install other packages without compiling PyClaw
+================================================
+If you get errors in the compilation step when using `pip install` or
+`python setup.py install`, check :ref:`trouble_installation`. 
+If your problem is not addressed there, please `let us know <claw-users@googlegroups.com>`_
+or `raise an issue <https://github.com/clawpack/clawpack/issues>`_.
+You can still use the Fortran codes (AMRClaw, GeoClaw, and Classic) by doing
+the following.  
+
+First, download a tarfile of the latest release as described in
+:ref:`install_clawpack`.  
+
+Next :ref:`setenv`.  You must then also set your PYTHONPATH manually::
+
+    export PYTHONPATH=$CLAW:$PYTHONPATH
 
 Then you should be able to do::
 
     cd $CLAW   # assuming this environment variable was properly set
     python setup.py symlink-only
 
-This last step creates some symbolic links (in the directory
-`$CLAW/clawpack`) that are needed in order for import
-statements to work properly in Python.  You should now be able to start a
-Python (or IPython) shell (from any directory)
-and do the following command, for example, with no error:
+This will create some symbolic links in the `$CLAW/clawpack` 
+subdirectory of your top level Clawpack directory, but does not compile code
+or put anything in your site-packages.
+In Python you should now be able to do the following, for example::
 
     >>> from clawpack import visclaw
 
 If not then either your `$PYTHONPATH` environment variable is not set
-properly, or the required symbolic links were not created.
+properly or the required symbolic links were not created.
 
-Next go to :ref:`first_run_fortran`.
-
-
-
-.. _install_fortran_pyclaw:
-
-Install for using both Fortran and PyClaw components
-=====================================================
-
-If you have installed using the procedure just described to 
-:ref:`install_fortran` and you also want to use :ref:`pyclaw` (to run Clawpack
-solvers directly from Python), then you can add one more step::
-
-    cd $CLAW
-    python setup.py install
-
-This will compile a lot of Fortran code using `f2py` and will produce a lot of 
-output, so you might want to redirect the output, e.g. ::
-
-    python setup.py install > install_output.txt
-
-If you get compilation errors in this step, you can still use the
-Fortran codes (and associated Python tools) without problems.
-
-To experiment with :ref:`pyclaw`, jump to :ref:`first_run_pyclaw`.  
-
-    >>> from clawpack import visclaw
-
+Next go to :ref:`first_run`.
 
 .. _install_pyclaw_parallel:
 
 Install only PyClaw (for running in parallel)
 ================================================
-First, install :ref:`pyclaw` as explained above.  Then see the install instructions
+First, install PyClaw as explained above.  Then see the install instructions
 for :ref:`parallel`.
 
 Alternatively, you may use the following shell scripts (assembled by Damian San Roman)
@@ -234,11 +214,38 @@ some installation options.
 - `NumPy <http://www.numpy.org/>`_  (for PyClaw/VisClaw)
 - `matplotlib <http://matplotlib.org/>`_ (for PyClaw/VisClaw)
 
-The `Anaconda Python Distribution <https://docs.continuum.io/anaconda/index>`_
-is an easy way to get all of these. 
-See :ref:`python` for more information on
+See :ref:`python` for information on
 installing the required modules and to get started using Python if
 you are not familiar with it.
 
   
 
+.. _first_test:
+
+Testing your installation 
+================================================
+
+PyClaw
+------
+If you downloaded Clawpack manually, you can test your PyClaw
+installation as follows (starting from your `clawpack` directory)::
+
+    cd pyclaw
+    nosetests
+
+This should return 'OK'.
+
+Classic
+-------
+As a first test of the Fortran code, try the following::
+
+    cd $CLAW/classic/tests
+    make tests
+
+This will run several tests and compare a few numbers from the solution with
+archived results.  The tests should run in a few seconds.
+
+There are similar `tests` subdirectories of `$CLAW/amrclaw` and
+`$CLAW/geoclaw` to do quick tests of these codes.
+
+See also :ref:`testing`.

--- a/doc/installing_pip.rst
+++ b/doc/installing_pip.rst
@@ -77,7 +77,7 @@ The recommended way to install the latest release of Clawpack, for
 using PyClaw and/or the Fortran packages, is to give the following pip
 install command::  
 
-    pip install --src=$HOME/src -e git+git@github.com:clawpack/clawpack.git@v5.3.1#egg=clawpack
+    pip install --src=$HOME/src -e git+https://github.com/clawpack/clawpack.git@v5.3.1#egg=clawpack
 
 This will install Clawpack into the directory `$HOME/src/clawpack`, or the
 installation directory can be changed by modifying the `--src` target

--- a/doc/installing_pip.rst
+++ b/doc/installing_pip.rst
@@ -1,0 +1,131 @@
+.. _installing_pip:
+
+**************************************
+Installation instructions (new)
+**************************************
+
+These instructions are a work in progress.  Suggestions welcome.
+
+For older installation instructions that contains more options, see
+:ref:`installing`.
+
+See also:
+
+* :ref:`clawpack_packages`
+* :ref:`changes`
+* :ref:`previous`
+* :ref:`trouble_installation`
+
+.. _install_prerequisites_pip:
+
+Installation Prerequisites
+================================================
+
+**Operating system:**
+
+- Linux
+- Mac OS X (you need to have the `Xcode developer tools
+  <http://developer.apple.com/technologies/tools/xcode.html>`_ installed in
+  order to have "make" working)
+
+
+**Fortran:**
+
+- `gfortran <http://gcc.gnu.org/wiki/GFortran>`_ or another F90 compiler
+
+See :ref:`fortran_compilers` for more about which compilers work well with
+Clawpack.
+For Mac OSX, see `hpc.sourceforge.net <http://hpc.sourceforge.net/>`_ for
+some installation options.
+
+**Python:**
+
+- Python Version 2.7 or above (but **not** 3.0 or above, which is not backwards compatible)
+- `NumPy <http://www.numpy.org/>`_  (for PyClaw/VisClaw)
+- `matplotlib <http://matplotlib.org/>`_ (for PyClaw/VisClaw)
+
+The `Anaconda Python Distribution <https://docs.continuum.io/anaconda/index>`_
+is an easy way to get all of these. 
+See :ref:`python` for more information on
+installing the required modules and to get started using Python if
+you are not familiar with it.
+
+**pip:**
+
+You may already have pip, in particular the Anaconda Python distribution
+contains pip. If you need to install it, see 
+`<https://pip.pypa.io/en/stable/installing/>`_
+
+
+**Git:**
+
+You may already have Git, in particular the Xcode tools on 
+Mac OSX contains Git.  If you need to install it, see `the Git book
+<https://git-scm.com/book/en/v2/Getting-Started-Installing-Git>`_.
+
+.. _install_quick:
+
+Quick Installation of all packages
+=====================================
+
+Please `register
+<http://depts.washington.edu/clawpack/register/index.html>`_ if you have not
+already done so.  This is purely optional, but is useful in helping us track
+the extent of usage.
+
+The recommended way to install the latest release of Clawpack, for
+using PyClaw and/or the Fortran packages, is to give the following pip
+install command::  
+
+    pip install --src=$HOME/src -e git+git@github.com:clawpack/clawpack.git@v5.3.1#egg=clawpack
+
+This will install Clawpack into the directory `$HOME/src/clawpack`, or the
+installation directory can be changed by modifying the `--src` target
+in this command.
+
+In order to use the Fortran versions, you should then set the environment
+variable `CLAW` to point to this directory, and `FC` to point to the desired
+Fortran compiler, e.g. ::
+
+    export CLAW=$HOME/src/clawpack
+    export FC=gfortran
+
+You may want to set `CLAW` even if you are only using PyClaw, since `$CLAW` is
+sometimes used in this documentation to indicate the top level of the
+Clawpack source directory structure.
+
+**Notes about pip install:**
+
+- The `-e` flag ("editable") results in the the source code
+  remaining in the directory `$CLAW`, which includes all the Fortran packages as
+  well as Python source.
+
+- Other released versions can be obtained by changing `v5.3.1` to a
+  different tag in the `pip install` command.
+  You can switch between versions or upgrade to a newer version by
+  repeating the above command with a different version number.
+  The directory `$HOME/src/clawpack` is a git clone of the top level
+  `clawpack` repository and "installing" a different version checks out
+  different tagged versions.
+
+- Earlier versions of the installation instructions required setting the
+  environment variable `PYTHONPATH`.  This is not necessary or desirable if
+  you use the `pip install` option, which instead
+  creates or modifies a file `easy_install.pth` that is
+  found in the Python `site-packages` directory.
+  The path to the clawpack source is added to this file and hence to the
+  search path for Python.  This allows importing Clawpack modules, but note
+  that directories specified here are searched before those specified by
+  the environment variable `PYTHONPATH`.  So if you wish to point to
+  a different version of the Clawpack Python tools, you need to rerun `pip
+  install`, or else remove the path from the `easy_install.pth` file if 
+  you need to use `PYTHONPATH`.
+
+
+Once Clawpack is installed, you can go to one of the following pages to get
+started:
+
+- :ref:`first_run_pyclaw`
+- :ref:`first_run_fortran`
+
+

--- a/doc/installing_pip.rst
+++ b/doc/installing_pip.rst
@@ -35,8 +35,6 @@ Installation Prerequisites
 
 See :ref:`fortran_compilers` for more about which compilers work well with
 Clawpack.
-For Mac OSX, see `hpc.sourceforge.net <http://hpc.sourceforge.net/>`_ for
-some installation options.
 
 **Python:**
 

--- a/doc/notebooks.rst
+++ b/doc/notebooks.rst
@@ -1,13 +1,14 @@
 
 .. _notebooks:
 
-IPython notebook examples
+Jupyter notebook examples
 =========================
 
-The `IPython notebook <http://ipython.org/notebook.html>`_
+The `Jupyter notebook <http://jupyter.org/>`_
+(formerly known as IPython notebook)
 is a very nice platform for illustrating Clawpack examples.
 
-If you have used Clawpack with the IPython notebook, please send us a link
+If you have used Clawpack with the Jupyter notebook, please send us a link
 or submit a pull request to the `apps repository <http://github.com/clawpack/apps>`_.
 The links below will take you to the nbviewer site, where you can view
 the notebooks as html.  You can also play animations in them and interact
@@ -49,9 +50,9 @@ here may not work with the current Clawpack.
 
 **Examples for GeoClaw:**
 
-* `IPython notebook illustrating topotools <http://nbviewer.ipython.org/url/clawpack.github.io/notebooks/topotools_examples.ipynb>`_
+* `Jupyter notebook illustrating topotools <http://nbviewer.ipython.org/url/clawpack.github.io/notebooks/topotools_examples.ipynb>`_
 
-* `IPython notebook illustrating dtopotools <http://nbviewer.ipython.org/url/clawpack.github.io/notebooks/dtopotools_examples.ipynb>`_
+* `Jupyter notebook illustrating dtopotools <http://nbviewer.ipython.org/url/clawpack.github.io/notebooks/dtopotools_examples.ipynb>`_
 
 * `IPython notebook illustrating the Okada model <http://nbviewer.ipython.org/url/clawpack.github.io/notebooks/Okada.ipynb>`_
 

--- a/doc/previous.rst
+++ b/doc/previous.rst
@@ -8,7 +8,17 @@ Previous versions of Clawpack
   `https://github.com/clawpack/clawpack/releases/
   <https://github.com/clawpack/clawpack/releases/>`_.
 
+* Recent versions can also be found on 
+  `Zenodo <https://zenodo.org>`_ with
+  permanent DOIs.  
+
+    * Version 5.3.1: `10.5281/zenodo.50982 <http://dx.doi.org/10.5281/zenodo.50982>`_
+
+  
+
 * The 4.6 version of Clawpack can be found 
   `here <http://depts.washington.edu/clawpack/download/downloadmenu.html>`_.
 
 * See :ref:`developers` for information on cloning from GitHub.
+
+Please also see :ref:`citing`.

--- a/doc/python.rst
+++ b/doc/python.rst
@@ -85,8 +85,7 @@ References and tutorials
 
 Some useful links to get started learning Python:
 
-   * `Enthought Python Distribution <http://www.enthought.com/products/epd.php>`_
-   * `Dive Into Python <http://www.diveintopython.org/>`_
+   * `Dive Into Python <http://www.diveintopython.net/>`_
 
    * `Python tutorial <http://www.python.org/doc/tut/>`_
    * `NumPy User Guide <http://docs.scipy.org/doc/numpy/user/>`_
@@ -94,7 +93,7 @@ Some useful links to get started learning Python:
    * `SciPy Reference Guide <http://docs.scipy.org/doc/scipy/reference/>`_
    * `Matplotlib gallery <http://matplotlib.sourceforge.net/gallery.html>`_
    * `LeVeque's class notes
-   * <http://faculty.washington.edu/rjl/classes/am583s2013/notes/python.html>`_ 
+     <http://faculty.washington.edu/rjl/classes/am583s2014/notes/python.html>`_ 
    * `Langtangen's book <http://folk.uio.no/hpl/scripting/>`_ and
      `Introductory slides <http://heim.ifi.uio.no/~hpl/scripting/all-nosplit/>`_
 
@@ -103,18 +102,4 @@ Notebooks
 ---------
 
 See :ref:`notebooks`.
-
-Sage
-----
-
-`Sage <http://www.sagemath.org/>`_ is an open source mathematics software 
-collection with its own interface and notebook system.  It is based on
-Python and the full distribution contains in particular
-the Python modules needed for Clawpack.
-
-You can try Sage directly from the
-web without downloading, click on "Try Sage Online" link on the
-`Sage <http://www.sagemath.org/>`_ webpage.
-
-We are working on incorporating Pyclaw into Sage as an optional package.
 

--- a/doc/testing.rst
+++ b/doc/testing.rst
@@ -7,24 +7,39 @@ Testing your installation
 
 PyClaw
 ------
+If you downloaded Clawpack manually, you can test your :ref:`pyclaw`
+installation as follows (starting from your `clawpack` directory)::
 
-Regression tests can be performed via::
 
-    cd $CLAW/pyclaw
+    cd pyclaw
     nosetests
 
-Fortran codes
--------------
+This should return 'OK'.
 
-Many repositories have a subdirectory named `tests` that contain a few
-regression tests that run very quickly and check that a few numbers
-determined from the solution agree with values stored in the example
-directories.  For example, to run some quick tests of `amrclaw`::
+Classic
+-------
+As a first test of the Fortran code, try the following::
 
-    cd $CLAW/amrclaw/tests
-    make tests
+    cd $CLAW/classic/tests
+    nosetests -sv
 
-will run several tests and report the results.
+
+This will run several tests and compare a few numbers from the solution with
+archived results.  The tests should run in a few seconds and 
+you should see output similar to this::
+
+    runTest (tests.acoustics_1d_heterogeneous.regression_tests.Acoustics1DHeterogeneousTest) ... ok
+    runTest (tests.acoustics_3d_heterogeneous.regression_tests.Acoustics3DHeterogeneousTest) ... ok
+    runTest (tests.advection_2d_annulus.regression_tests.Advection2DAnnulusTest) ... ok
+
+    ----------------------------------------------------------------------
+    Ran 3 tests in 4.639s
+    OK
+
+
+There are similar `tests` subdirectories of `$CLAW/amrclaw` and
+`$CLAW/geoclaw` to do quick tests of these codes.
+
 
 More extensive tests can be performed by running all of the examples in the
 `examples` directory and comparing the resulting plots against those


### PR DESCRIPTION
Tried to simplify instructions for Fortran users.

This draft version now appears at
   http://www.clawpack.org/installing.html

For comparison, the old is at
   http://www.clawpack.org/installing_old.html

Suggestions welcome.  

Are the PyClaw instructions still ok?