### PR TITLE
Properly specify path to clawlogo in layout.html.

### DIFF
--- a/doc/_themes/flask/layout.html
+++ b/doc/_themes/flask/layout.html
@@ -7,7 +7,7 @@
 
 {%- block sidebarlogo %}
 <p><a href="http://clawpack.org/">
-    <img class="logo" src= "{{ asset_root }}/clawlogo.jpg" alt="Logo"/>
+    <img class="logo" src= "{{ pathto("_static/clawlogo.jpg",1) }}" alt="Logo"/>
 </a>
 <h2>Version {{ release }}</h2>
 </p>


### PR DESCRIPTION
This makes the logo show up correctly on pages in subdirectories (like PyClaw pages).