### PR TITLE
Make PyClaw gallery work with multiple examples in each directory.

### DIFF
--- a/doc/pyclaw/gallery/gallery.py
+++ b/doc/pyclaw/gallery/gallery.py
@@ -3,41 +3,40 @@ Module for making galleries of thumbnails allowing easy browsing of
 applications directories.
 
 These tools assume that the examples have already been run and the plots
-produced using the script make_plots.py.  
+produced using the script make_plots.py.
 
 """
-
 import os
+from clawpack import pyclaw
 
 
 # Main root for html links:
-#claw_html_root='http://localhost:50005'     
+# claw_html_root='http://localhost:50005'
 claw_html_root='..'
 
-from clawpack import pyclaw
 # Determine Clawpack directory:
 try:
     clawdir_default = os.environ['CLAW']+'/'
 except KeyError:
     clawdir_default = os.path.join('/'.join(pyclaw.__path__[0].split('/')[:-1])+'/')
-    print 'CLAW environment variable not set; using '+clawdir_default
+    print('CLAW environment variable not set; using '+clawdir_default)
 
 # Location for gallery files:
-gallery_dir_default = '.'#os.path.join(clawdir_default,'doc/gallery')  
+gallery_dir_default = '.'  # os.path.join(clawdir_default,'doc/gallery')
 
 remake = True   # True ==> remake all thumbnails even if they exist.
 
 class GalleryItem(object):
-    
+
     def __init__(self, appdir, appname, plotdir, description, images):
         self.appdir = appdir
         self.appname = appname
-        self.plotdir = plotdir
+        self.plotdir = '_plots_'+appname
         self.description = description
         self.images = images
 
 class GallerySection(object):
-    
+
     def __init__(self,title,description=""):
         self.title = title
         self.description = description
@@ -50,7 +49,7 @@ class GallerySection(object):
 
 
 class Gallery(object):
-    
+
     def __init__(self, title, clawdir=clawdir_default):
         self.title = title
         self.clawdir = clawdir
@@ -62,25 +61,25 @@ class Gallery(object):
         gsec.items = []
         self.sections.append(gsec)
         return gsec
-    
+
     def create(self,fname,gallery_dir=None, copy_plots=True, write_file=True):
 
         # Directory for gallery files:
         if gallery_dir is None:
             gallery_dir = gallery_dir_default
 
-        print "Gallery files will be created in directory "
-        print "   ", gallery_dir
+        print("Gallery files will be created in directory ")
+        print("   ", gallery_dir)
 
         try:
             if not os.path.isdir(gallery_dir):
                 os.system('mkdir %s' % gallery_dir)
-                print "Created directory ",gallery_dir
+                print("Created directory ",gallery_dir)
             start_dir = os.getcwd()
             os.chdir(gallery_dir)
         except:
-            print "*** Error moving to directory ",gallery_dir
-            print "*** Gallery not created"
+            print("*** Error moving to directory ",gallery_dir)
+            print("*** Gallery not created")
             raise
 
         if write_file:
@@ -96,8 +95,8 @@ class Gallery(object):
         gfile.write(nchar*"=" + "\n")
         gfile.write(".. contents::\n\n")
 
-        #gfile.write("%s\n" % self.title)
-        #gfile.write("="*len(self.title)+"\n\n")
+        # gfile.write("%s\n" % self.title)
+        # gfile.write("="*len(self.title)+"\n\n")
 
         for gsec in self.sections:
             gfile.write("%s\n" % gsec.title)
@@ -112,23 +111,24 @@ class Gallery(object):
 
                 if not os.path.exists(static_dir+gitem.appdir):
                     os.system('mkdir -p %s' % (static_dir+gitem.appdir))
-                print "+++ static_dir = ",static_dir+gitem.appdir
+                print("+++ static_dir = "+static_dir+gitem.appdir)
 
                 if copy_plots:
-                    os.system('cp -r %s/_plots %s' % (self.clawdir+gitem.appdir, \
-                                static_dir+gitem.appdir))
+                    os.system('cp -r %s/%s %s' % (self.clawdir+gitem.appdir,
+                              gitem.plotdir, static_dir+gitem.appdir+'/'+gitem.plotdir))
 
                 gfile.write('\n')
                 desc = gitem.description.lstrip().replace('\n',' ')
                 gfile.write('%s\n\n' % desc)
-                plotindex = os.path.join(claw_html_root, '../_static', \
-                        gitem.appdir, gitem.plotdir, '_PlotIndex.html')
+                plotindex = os.path.join(claw_html_root, '../_static',
+                                         gitem.appdir, gitem.plotdir,
+                                         '_PlotIndex.html')
                 sourcepage = gitem.appname+'.html'
-                gfile.write('`Source code <%s>`__ ... \n`Plots <%s>`__\n' \
-                      % (sourcepage,plotindex))
+                gfile.write('`Source code <%s>`__ ... \n`Plots <%s>`__\n'
+                            % (sourcepage,plotindex))
 
                 if not os.path.exists('./'+gitem.appdir):
-                    os.makedirs ('./'+gitem.appdir)
+                    os.makedirs('./'+gitem.appdir)
                 gfile.write('\n\n')
 
                 # For each example, write a page containing the source
@@ -148,19 +148,19 @@ class Gallery(object):
 
                     src_name = os.path.join(gitem.appdir, gitem.plotdir, image)
                     thumb_name = src_name.replace('/','_')
-                    src_html = os.path.join(claw_html_root,'../_static', \
-                        src_name) + '.html'
+                    src_html = os.path.join(claw_html_root,'../_static',
+                                            src_name) + '.html'
                     src_name = os.path.join(self.clawdir,src_name)
                     src_png = src_name + '.png'
                     if not os.path.isdir('thumbnails'):
-                        print "Creating directory thumbnails"
+                        print("Creating directory thumbnails")
                         os.system('mkdir thumbnails')
                     thumb_file = os.path.join('thumbnails',thumb_name + '.png')
                     if os.path.isfile(thumb_file) and (not remake):
-                        print "Thumbnail exists: ",thumb_file
+                        print("Thumbnail exists: ",thumb_file)
                     else:
                         scale = 0.3
-                        make_thumb(src_png ,thumb_file, scale)
+                        make_thumb(src_png, thumb_file, scale)
 
                     gfile.write('.. image:: %s\n   :width: 5cm\n' % thumb_file)
                     gfile.write('   :target: %s\n' % src_html)
@@ -177,25 +177,23 @@ class Gallery(object):
                 rf.write('.. literalinclude:: ../../../../'+gitem.appdir+'/'+gitem.appname+'.py'+'\n')
                 rf.close()
 
-
-        print "Created ",fname, " in directory ", os.getcwd()
+        print("Created ",fname, " in directory ", os.getcwd())
         os.chdir(start_dir)
-                    
+
 
 def make_thumb(src_file, thumb_file, scale):
-    
-    from numpy import floor 
+
+    from numpy import floor
     if not os.path.exists(src_file):
-        print '*** Error in make_thumb: cannot find file ',src_file
+        print('*** Error in make_thumb: cannot find file ',src_file)
     else:
         # convert scale to percent:
         scale = int(floor(scale*100))
-        os.system('convert -resize %s' % scale + '% ' + \
-            '%s %s' % (src_file, thumb_file))
-        #print "Converted ",src_file
-        #print "   to     ",thumb_file
+        os.system('convert -resize %s' % scale + '% ' +
+                  '%s %s' % (src_file, thumb_file))
+        # print("Converted ",src_file)
+        # print("   to     ",thumb_file)
 
-   
 
 def test():
     gallery = Gallery(title="Test Gallery")
@@ -208,17 +206,15 @@ def test():
         Advecting Gaussian with periodic boundary."""
     images = ('frame0000fig1', 'frame0004fig1')
     gsec.new_item(appdir, appname, plotdir, description, images)
-       
-    gallery.create('test.rst')
 
+    gallery.create('test.rst')
 
 
 def make_1d():
     gallery = Gallery(title="Gallery of 1d PyClaw applications")
     plotdir = '_plots'
 
-
-    #----------------------------------------------
+    # ----------------------------------------------
     gsec = gallery.new_section('1-dimensional advection')
     appdir = 'pyclaw/examples/advection_1d'
     appname = 'advection_1d'
@@ -226,7 +222,7 @@ def make_1d():
          Advecting Gaussian with periodic boundary."""
     images = ('frame0000fig1', 'frame0004fig1', 'frame0010fig1')
     gsec.new_item(appdir, appname, plotdir, description, images)
-    #----------------------------------------------
+    # ----------------------------------------------
     gsec = gallery.new_section('1-dimensional variable-velocity advection')
     appdir = 'pyclaw/examples/advection_1d_variable'
     appname = 'variable_coefficient_advection'
@@ -234,7 +230,7 @@ def make_1d():
          Advecting Gaussian and square wave with periodic boundary."""
     images = ('frame0000fig1', 'frame0004fig1', 'frame0008fig1')
     gsec.new_item(appdir, appname, plotdir, description, images)
-     #----------------------------------------------
+    # ----------------------------------------------
     gsec = gallery.new_section('1-dimensional acoustics')
     appdir = 'pyclaw/examples/acoustics_1d_homogeneous'
     appname = 'acoustics_1d'
@@ -243,7 +239,7 @@ def make_1d():
          right."""
     images = ('frame0000fig1', 'frame0002fig1', 'frame0005fig1')
     gsec.new_item(appdir, appname, plotdir, description, images)
-    #----------------------------------------------
+    # ----------------------------------------------
     gsec = gallery.new_section("1-dimensional Burgers' equation")
     appdir = 'pyclaw/examples/burgers_1d'
     appname = 'burgers_1d'
@@ -252,14 +248,19 @@ def make_1d():
         N-wave.  """
     images = ('frame0000fig0', 'frame0003fig0', 'frame0006fig0')
     gsec.new_item(appdir, appname, plotdir, description, images)
-    #----------------------------------------------
+    # ----------------------------------------------
     gsec = gallery.new_section("1-dimensional shallow water equation")
     appdir = 'pyclaw/examples/shallow_1d'
     appname = 'dam_break'
     description = """Shallow water shock tube."""
     images = ('frame0000fig0', 'frame0003fig0', 'frame0006fig0')
     gsec.new_item(appdir, appname, plotdir, description, images)
-    #----------------------------------------------
+
+    appname = 'sill'
+    description = """Flow over a sill."""
+    images = ('frame0000fig0', 'frame0003fig0', 'frame0006fig0')
+    gsec.new_item(appdir, appname, plotdir, description, images)
+    # ----------------------------------------------
     gsec = gallery.new_section("1-dimensional nonlinear elasticity")
     appdir = 'pyclaw/examples/stegoton_1d'
     appname = 'stegoton'
@@ -268,7 +269,7 @@ def make_1d():
         """
     images = ('frame0000fig1', 'frame0003fig1', 'frame0005fig1')
     gsec.new_item(appdir, appname, plotdir, description, images)
-    #----------------------------------------------
+    # ----------------------------------------------
     gsec = gallery.new_section("1-dimensional Euler equations")
     appdir = 'pyclaw/examples/euler_1d'
     description = """
@@ -277,8 +278,19 @@ def make_1d():
     appname = 'woodward_colella_blast'
     images = ('frame0000fig0', 'frame0003fig0', 'frame0010fig0')
     gsec.new_item(appdir, appname, plotdir, description, images)
-    #----------------------------------------------
-       
+
+    description = """ Shu-Osher problem.  """
+    appname = 'shocksine'
+    images = ('frame0000fig0', 'frame0003fig0', 'frame0010fig0')
+    gsec.new_item(appdir, appname, plotdir, description, images)
+
+    description = """ Shock tube problem.  """
+    appname = 'shocktube'
+    images = ('frame0000fig0', 'frame0003fig0', 'frame0010fig0')
+    gsec.new_item(appdir, appname, plotdir, description, images)
+
+    # ----------------------------------------------
+
     gallery.create('gallery_1d.rst', write_file=False)
     return gallery
 
@@ -287,103 +299,126 @@ def make_2d():
     gallery = Gallery("Gallery of 2d PyClaw applications")
     plotdir = '_plots'
 
-    #----------------------------------------------
+    # ----------------------------------------------
     gsec = gallery.new_section('2-dimensional advection')
-    #----------------------------------------------
+    # ----------------------------------------------
     appdir = 'pyclaw/examples/advection_2d'
     appname = 'advection_2d'
     description = """
         Advecting square with periodic boundary conditions."""
     images = ('frame0000fig0', 'frame0002fig0', 'frame0004fig0')
     gsec.new_item(appdir, appname, plotdir, description, images)
-    #----------------------------------------------
+    # ----------------------------------------------
 
-    #----------------------------------------------
+    # ----------------------------------------------
     gsec = gallery.new_section('2-dimensional variable-coefficient advection')
-    #----------------------------------------------
+    # ----------------------------------------------
     appdir = 'pyclaw/examples/advection_2d_annulus'
     appname = 'advection_annulus'
     description = """
         Advection in an annular region."""
     images = ('frame0000fig0', 'frame0004fig0', 'frame0008fig0')
     gsec.new_item(appdir, appname, plotdir, description, images)
-    #----------------------------------------------
+    # ----------------------------------------------
 
-    #----------------------------------------------
+    # ----------------------------------------------
     gsec = gallery.new_section('2-dimensional acoustics')
-    #----------------------------------------------
+    # ----------------------------------------------
     appdir = 'pyclaw/examples/acoustics_2d_homogeneous'
     appname = 'acoustics_2d'
     description = """
         Expanding radial acoustic wave in a homogeneous medium."""
     images = ('frame0000fig0', 'frame0002fig0', 'frame0004fig0')
     gsec.new_item(appdir, appname, plotdir, description, images)
-    #----------------------------------------------
+    # ----------------------------------------------
 
-    #----------------------------------------------
+    # ----------------------------------------------
     gsec = gallery.new_section('2-dimensional variable-coefficient acoustics')
-    #----------------------------------------------
+    # ----------------------------------------------
     appdir = 'pyclaw/examples/acoustics_2d_variable'
     appname = 'acoustics_2d_interface'
     description = """
         Expanding radial acoustic wave in a two-material medium with an interface."""
     images = ('frame0000fig0', 'frame0010fig0', 'frame0020fig0')
     gsec.new_item(appdir, appname, plotdir, description, images)
-    #----------------------------------------------
 
-    #----------------------------------------------
+    appdir = 'pyclaw/examples/acoustics_2d_mapped'
+    appname = 'acoustics_2d_inclusions'
+    description = """
+        Acoustic wave scattered by two cylinders."""
+    images = ('frame0000fig0', 'frame0010fig0', 'frame0020fig0')
+    gsec.new_item(appdir, appname, plotdir, description, images)
+    # ----------------------------------------------
+
+    gsec = gallery.new_section('2-dimensional advection-reaction')
+    appdir = 'pyclaw/examples/advection_reaction_2d'
+    appname = 'advection_reaction'
+    description = ""
+    images = ('frame0000fig0', 'frame0004fig0', 'frame0010fig0')
+    gsec.new_item(appdir, appname, plotdir, description, images)
+
+    # ----------------------------------------------
     gsec = gallery.new_section('2-dimensional shallow water equations')
-    #----------------------------------------------
+    # ----------------------------------------------
     appdir = 'pyclaw/examples/shallow_2d'
     appname = 'radial_dam_break'
     description = """Radial dam-break."""
     images = ('frame0000fig0', 'frame0004fig0', 'frame0010fig0')
     gsec.new_item(appdir, appname, plotdir, description, images)
-    #----------------------------------------------
+    # ----------------------------------------------
 
-    #----------------------------------------------
+    # ----------------------------------------------
     gsec = gallery.new_section('2-dimensional shallow water on the sphere')
-    #----------------------------------------------
+    # ----------------------------------------------
     appdir = 'pyclaw/examples/shallow_sphere'
     appname = 'Rossby_wave'
     description = """Wavenumber 4 Rossby-Haurwitz wave on a rotating sphere."""
     images = ('frame0000fig0', 'frame0004fig0', 'frame0010fig0')
     gsec.new_item(appdir, appname, plotdir, description, images)
-    #----------------------------------------------
+    # ----------------------------------------------
 
-    #----------------------------------------------
+    # ----------------------------------------------
     gsec = gallery.new_section('2-dimensional Euler equations')
-    #----------------------------------------------
+    # ----------------------------------------------
     appdir = 'pyclaw/examples/euler_2d'
     appname = 'shock_bubble_interaction'
-    description = """
-        Shock-bubble interaction."""
+    description = """ Shock-bubble interaction."""
     images = ('frame0000fig0', 'frame0004fig0', 'frame0010fig0')
     gsec.new_item(appdir, appname, plotdir, description, images)
-    #----------------------------------------------
 
-    #----------------------------------------------
+    appname = 'shock_forward_step'
+    description = """ Shockwave hitting a step."""
+    images = ('frame0000fig0', 'frame0004fig0', 'frame0010fig0')
+    gsec.new_item(appdir, appname, plotdir, description, images)
+
+    appname = 'quadrants'
+    description = """Quadrants: 2D Riemann problem with four shockwaves."""
+    images = ('frame0000fig0', 'frame0004fig0', 'frame0010fig0')
+    gsec.new_item(appdir, appname, plotdir, description, images)
+    # ----------------------------------------------
+
+    # ----------------------------------------------
     gsec = gallery.new_section('2-dimensional KPP equation')
-    #----------------------------------------------
+    # ----------------------------------------------
     appdir = 'pyclaw/examples/kpp'
     appname = 'kpp'
     description = """
         Non-convex flux example."""
     images = ('frame0000fig1', 'frame0004fig1', 'frame0010fig1')
     gsec.new_item(appdir, appname, plotdir, description, images)
-    #----------------------------------------------
+    # ----------------------------------------------
 
-    #----------------------------------------------
+    # ----------------------------------------------
     gsec = gallery.new_section('2-dimensional p-system')
-    #----------------------------------------------
+    # ----------------------------------------------
     appdir = 'pyclaw/examples/psystem_2d'
     appname = 'psystem_2d'
     description = """
         Radial wave in a checkerboard-like medium."""
     images = ('frame0000fig0', 'frame0004fig0', 'frame0010fig0')
     gsec.new_item(appdir, appname, plotdir, description, images)
-    #----------------------------------------------
-        
+    # ----------------------------------------------
+
     gallery.create('gallery_2d.rst', write_file=False)
     return gallery
 
@@ -393,8 +428,9 @@ def make_all():
 
     # make gallery of everything:
     gallery_all = Gallery(title="Gallery of all PyClaw applications")
-    gallery_all.sections = gallery_1d.sections + gallery_2d.sections 
+    gallery_all.sections = gallery_1d.sections + gallery_2d.sections
     gallery_all.create('gallery_all.rst')
+
 
 if __name__ == "__main__":
     make_all()

--- a/doc/pyclaw/gallery/make_plots.py
+++ b/doc/pyclaw/gallery/make_plots.py
@@ -3,6 +3,8 @@ Runs code in each example directory to create sample results for webpage.
 
 Sends output and errors to separate files to simplify looking for errors.
 """
+import os
+import sys
 
 
 def list_examples(examples_dir=None):
@@ -18,22 +20,22 @@ def list_examples(examples_dir=None):
     examples_dir = os.path.abspath(examples_dir)
     current_dir = os.getcwd()
     os.chdir(examples_dir)
-    
+
     dirlist = []
     applist = []
 
     # Traverse directories depth-first (topdown=False) to insure e.g. that code in
     # book/chap21/radialdam/1drad is run before code in book/chap21/radialdam
     for (dirpath, subdirs, files) in os.walk('.',topdown=False):
-        #By convention we assume that all python scripts are applications
-        #unless they are named 'setup.py' or 'setplot.py' or have 'test' in their name.
+        # By convention we assume that all python scripts are applications
+        # unless they are named 'setup.py' or 'setplot.py' or have 'test' in their name.
         files = os.listdir(os.path.abspath(dirpath))
         pyfiles=[f for f in files if f.split('.')[-1]=='py']
         appfiles=[f for f in pyfiles if f.split('.')[0] not in ('setup','setplot','__init__')]
         appfiles=[f for f in appfiles if 'test' not in f]
         appfiles=[f for f in appfiles if 'peano' not in dirpath]
         appfiles=[f for f in appfiles if 'compare_solvers' not in f]
-        #Skip 3d for now because visclaw plotting is not set up for it
+        # Skip 3d for now because visclaw plotting is not set up for it
         appfiles=[file for file in appfiles if '3d' not in os.path.abspath(dirpath)]
 
         for filename in appfiles:
@@ -43,8 +45,9 @@ def list_examples(examples_dir=None):
     os.chdir(current_dir)
 
     return applist, dirlist
-        
-def run_examples(examples_dir = None):
+
+
+def run_examples(examples_dir=None):
     """
     Runs all examples in subdirectories of examples_dir.
     """
@@ -55,31 +58,30 @@ def run_examples(examples_dir = None):
 
     app_list, dir_list = list_examples(examples_dir)
     for app, directory in zip(app_list,dir_list):
-        print directory, app
+        print(directory+' '+app)
+        app_name = app.split('.')[0]
         os.chdir(directory)
-        process = subprocess.Popen(['python',app])#, stdout = subprocess.PIPE)
+        process = subprocess.Popen(['python', app, 'outdir=_'+app_name])  # , stdout = subprocess.PIPE)
         stdout, stderr = process.communicate()
 
     os.chdir(current_dir)
 
 
-def make_plots(examples_dir = None):
-    import os,sys
-
+def make_plots(examples_dir=None):
     if examples_dir is None:
         from clawpack import pyclaw
         examples_dir = pyclaw.__path__[0]+'/examples'
 
     examples_dir = os.path.abspath(examples_dir)
     current_dir = os.getcwd()
- 
-    print "Will run code and make plots in every subdirectory of "
-    print "    ", examples_dir
+
+    print("Will run code and make plots in every subdirectory of ")
+    print("    "+examples_dir)
     ans = raw_input("Ok? ")
     if ans.lower() not in ['y','yes']:
-        print "Aborting."
+        print("Aborting.")
         sys.exit()
-    
+
     fname_output = 'make_plots_output.txt'
     fout = open(fname_output, 'w')
     fout.write("ALL OUTPUT FROM RUNNING EXAMPLES\n\n")
@@ -92,11 +94,11 @@ def make_plots(examples_dir = None):
 
     goodlist_run = []
     badlist_run = []
-    
+
     app_list, dir_list = list_examples(examples_dir)
     import subprocess
-    for appname, directory in zip(app_list,dir_list):
-        print 'Running ', directory, appname
+    for appfile, directory in zip(app_list,dir_list):
+        print('Running '+directory, appfile)
 
         fout.write("\n=============================================\n")
         fout.write(directory)
@@ -108,43 +110,45 @@ def make_plots(examples_dir = None):
         # flush I/O buffers:
         fout.flush()
         ferr.flush()
-    
+
         os.chdir(directory)
-        job = subprocess.Popen(['python','./'+appname,'htmlplot=True'], stdout = fout, stderr = ferr)
+        job = subprocess.Popen(['python','./'+appfile,'htmlplot=True'], stdout=fout, stderr=ferr)
         return_code = job.wait()
         if return_code == 0:
-            print "   Successful run"
+            print("   Successful run")
             goodlist_run.append(directory)
         else:
-            print "   *** Run errors encountered: see ", fname_errors
+            print("   *** Run errors encountered: see "+fname_errors)
             badlist_run.append(directory)
+        app_name = appfile.split('.')[0]
+        job = subprocess.Popen(['mv', '_plots', '_plots_'+app_name])
 
     if len(goodlist_run)>0:
-        print ' '
-        print 'Ran PyClaw and created output and plots in directories:'
+        print(' ')
+        print('Ran PyClaw and created output and plots in directories:')
         for d in goodlist_run:
-            print '   ',d
-        print ' '
-    
+            print('   '+d)
+        print(' ')
+
     if len(badlist_run)>0:
-        print 'Run or plot errors encountered in the following directories:'
+        print('Run or plot errors encountered in the following directories:')
         for d in badlist_run:
-            print '   ',d
-        print ' '
+            print('   '+d)
+        print(' ')
     else:
-        print 'All examples ran and plotted successfully.'
-    
+        print('All examples ran and plotted successfully.')
+
     fout.close()
     ferr.close()
-    print 'For all output see ', fname_output
-    print 'For all errors see ', fname_errors
+    print('For all output see '+fname_output)
+    print('For all errors see '+fname_errors)
 
     os.chdir(current_dir)
 
+
 if __name__=='__main__':
-    import sys
     if len(sys.argv)>1:
-        print sys.argv
+        print(sys.argv)
         make_plots(sys.argv[1])
     else:
         make_plots()


### PR DESCRIPTION
This was previously written under the assumption that there
was only one example in each subdirectory of pclaw/examples.
Nowadays there are multiple examples in some directories
(different problems but with the same set of equations).
This updates the gallery-building scripts to work with that
situation by using e.g. "_plots_advection_1d" instead of just "_plots".

docathon