### PR TITLE
added amrclaw_doxygen.rst and related updates

### DIFF
--- a/doc/amr_algorithm.rst
+++ b/doc/amr_algorithm.rst
@@ -161,3 +161,7 @@ The user can control the criteria used for flagging cells for refinement.
 
 See :ref:`refinement` for details.
 
+For more details
+----------------
+
+See :ref:`amrclaw_doxygen`.

--- a/doc/amrclaw.rst
+++ b/doc/amrclaw.rst
@@ -14,6 +14,7 @@ also be used for 1-dimensional problems, see :ref:`amrclaw_1d`.)
 
 * :ref:`amr_algorithm`
 * :ref:`refinement`
+* :ref:`amrclaw_doxygen`
 
 Block-structured AMR is implemented, in which rectangular patches of the
 grid at level `L` are refined to level `L+1`.  

--- a/doc/amrclaw_doxygen.rst
+++ b/doc/amrclaw_doxygen.rst
@@ -1,0 +1,20 @@
+
+.. _amrclaw_doxygen:
+
+Doxygen documentation of AMRClaw
+================================
+
+Under Development!
+
+We are currently adding documentation to the Fortran files in AMRClaw so that
+documentation can be generated using `Doxygen
+<http://www.stack.nl/~dimitri/doxygen/>`_
+
+The resulting documentation pages give a description of the parameters and
+also will show call graphs to help understand what other subroutines call a
+subroutine or are called by it.  For an example, see
+`filpatch.f90 <http://www.clawpack.org/doxygen/amrclaw/2d/filpatch_8f90.html>`_.
+
+See `the file list <http://www.clawpack.org/doxygen/amrclaw/2d/files.html>`_ for
+a list of the AMRClaw files.
+

--- a/doc/doxygen/amrclaw/2d/README.md
+++ b/doc/doxygen/amrclaw/2d/README.md
@@ -1,0 +1,11 @@
+
+First make html files via
+
+```
+    doxygen doxygen.conf
+```
+
+Then move to the web via:
+
+```
+    source rsync_clawpack.github.sh

--- a/doc/doxygen/amrclaw/2d/rsync_clawpack.github.sh
+++ b/doc/doxygen/amrclaw/2d/rsync_clawpack.github.sh
@@ -1,0 +1,2 @@
+
+rsync -azv doc/html/ ../../../../../clawpack.github.com/doxygen/amrclaw/2d/


### PR DESCRIPTION
See http://www.clawpack.org/amrclaw_doxygen.html

Currently you must check out doxygen branch of amrclaw from @xinshengqin  to get call graphs to show up, until clawpack/amrclaw#189 is merged. That PR only has new documentation and call graphs for a few subroutines.  More will be added later.