### PR TITLE
change _templates/index.html to point to new galleries

### DIFF
--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -90,7 +90,7 @@ If you use Clawpack in published work please see <a href="{{ pathto("about") }}#
 
   <table class="contentstable" align="center" style="margin-left: 30px"><tr>
     <td width="50%">
-      <p class="biglink"><a class="biglink" href="{{ pathto("galleries") }}">{%trans%}Applications gallery {%endtrans%}</a><br/>
+      <p class="biglink"><a class="biglink" href="http://www.clawpack.org/gallery/index.html">{%trans%}Applications gallery {%endtrans%}</a><br/>
          <span class="linkdescr">{%trans%}Examples of Clawpack, PyClaw,
 AMRClaw, and GeoClaw simulation results{%endtrans%}</span></p>
     </td></tr>


### PR DESCRIPTION
To address #176.  

I also replaced the stale `clawpack/github.com.git/galleries.html` (which is no longer generated by sphinx since we moved the galleries) by a page with a link to the correct location in case someone has the old page bookmarked.

See http://www.clawpack.org/galleries.html

We might want to write a script so that old versions such as `http://www.clawpack.org/v5.4.0/galleries.html` also point to this page. This is where you land if you select v5.4.0 and then click Gallery at the top, since it builds from the v5.4.0 tag on Github. 

