### PR TITLE
Create galleries.html file with pointer to new galleries

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -137,4 +137,10 @@ doctest:
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/doctest/output.txt."
 
+versions:
+	sphinx-versioning build -i -r master doc ./_build/html
+	source cp_galleries.sh
 
+vtest:
+	ls -l ./_build/html/galleries.html
+	bash ./cp_galleries.sh

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -139,8 +139,5 @@ doctest:
 
 versions:
 	sphinx-versioning build -i -r master doc ./_build/html
-	source cp_galleries.sh
+	bash cp_galleries.sh
 
-vtest:
-	ls -l ./_build/html/galleries.html
-	bash ./cp_galleries.sh

--- a/doc/cp_galleries.sh
+++ b/doc/cp_galleries.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+VERSIONS="_build/html/master `ls -d _build/html/v5*`"
+
+for dir in $VERSIONS
+do
+    echo copying _build/html/galleries.html to $dir/galleries.html
+    cp _build/html/galleries.html $dir/galleries.html
+done

--- a/doc/galleries.rst
+++ b/doc/galleries.rst
@@ -1,0 +1,9 @@
+:orphan:
+
+.. _galleries:
+
+The Clawpack Gallery is available only for the latest release of Clawpack.
+
+Please see
+`<http://www.clawpack.org/gallery/index.html>`_.
+


### PR DESCRIPTION
Plus script to copy this file to all old versions, overwriting old versions of gallery with error messages.

Modified Makefile to `make versions`