### PR TITLE
Prepend 'clawpack' to pyclaw autodoc paths.

### DIFF
--- a/doc/pyclaw/controller.rst
+++ b/doc/pyclaw/controller.rst
@@ -43,7 +43,7 @@ work in its entirety.
 :class:`pyclaw.controller.Controller`
 =====================================
 
-.. autoclass:: pyclaw.controller.Controller
+.. autoclass:: clawpack.pyclaw.controller.Controller
    :members:
    :member-order: groupwise
    

--- a/doc/pyclaw/geometry.rst
+++ b/doc/pyclaw/geometry.rst
@@ -52,7 +52,7 @@ Serial Geometry Objects
 :class:`pyclaw.geometry.Domain`
 =================================
 
-.. autoclass:: pyclaw.geometry.Domain
+.. autoclass:: clawpack.pyclaw.geometry.Domain
    :members:
    :member-order: groupwise
 
@@ -60,7 +60,7 @@ Serial Geometry Objects
 :class:`pyclaw.geometry.Patch`
 =================================
 
-.. autoclass:: pyclaw.geometry.Patch
+.. autoclass:: clawpack.pyclaw.geometry.Patch
    :members:
    :member-order: groupwise
    :show-inheritance:
@@ -69,7 +69,7 @@ Serial Geometry Objects
 :class:`pyclaw.geometry.Grid`
 =================================
 
-.. autoclass:: pyclaw.geometry.Grid
+.. autoclass:: clawpack.pyclaw.geometry.Grid
    :members:
    :member-order: groupwise
    
@@ -77,7 +77,7 @@ Serial Geometry Objects
 :class:`pyclaw.geometry.Dimension`
 ==================================
 
-.. autoclass:: pyclaw.geometry.Dimension
+.. autoclass:: clawpack.pyclaw.geometry.Dimension
    :members:
    :member-order: groupwise
 
@@ -89,7 +89,7 @@ Parallel Geometry Objects
 :class:`petclaw.geometry.Domain`
 ===================================
 
-.. autoclass:: petclaw.geometry.Domain
+.. autoclass:: clawpack.petclaw.geometry.Domain
    :members:
    :member-order: groupwise
    :show-inheritance:
@@ -97,7 +97,7 @@ Parallel Geometry Objects
 :class:`petclaw.geometry.Patch`
 ===============================
 
-.. autoclass:: petclaw.geometry.Patch
+.. autoclass:: clawpack.petclaw.geometry.Patch
   :members:
   :member-order: groupwise
   :show-inheritance:

--- a/doc/pyclaw/index.rst
+++ b/doc/pyclaw/index.rst
@@ -47,7 +47,6 @@ PyClaw Documentation
    troubleshooting
    about
    gallery/gallery_all
-   gallery/how-to-build
 
 
 .. _pyclaw_reference:

--- a/doc/pyclaw/io.rst
+++ b/doc/pyclaw/io.rst
@@ -68,7 +68,7 @@ libraries needed.
 :mod:`pyclaw.io.ascii`
 ======================
 
-.. automodule:: pyclaw.io.ascii
+.. automodule:: clawpack.pyclaw.fileio.ascii
     :members:
     
 .. _HDF5:
@@ -76,7 +76,7 @@ libraries needed.
 :mod:`pyclaw.io.hdf5`
 =====================
 
-.. automodule:: pyclaw.io.hdf5
+.. automodule:: clawpack.pyclaw.fileio.hdf5
     :members:
 
 .. _NetCDF:
@@ -84,5 +84,5 @@ libraries needed.
 :mod:`pyclaw.io.netcdf`
 =======================
 
-.. automodule:: pyclaw.io.netcdf
+.. automodule:: clawpack.pyclaw.fileio.netcdf
     :members:

--- a/doc/pyclaw/solution.rst
+++ b/doc/pyclaw/solution.rst
@@ -48,6 +48,6 @@ List of serial and parallel objects in a :class:`~pyclaw.solution.Solution` clas
 :class:`pyclaw.solution.Solution`
 =================================
 
-.. autoclass:: pyclaw.solution.Solution
+.. autoclass:: clawpack.pyclaw.solution.Solution
    :members:
    :member-order: groupwise

--- a/doc/pyclaw/solvers.rst
+++ b/doc/pyclaw/solvers.rst
@@ -93,7 +93,7 @@ about the methods and attributes they provide each class.
 :mod:`pyclaw.sharpclaw`
 ===============================
 
-.. autoclass:: pyclaw.sharpclaw.solver.SharpClawSolver
+.. autoclass:: clawpack.pyclaw.sharpclaw.solver.SharpClawSolver
    :members:
 
 

--- a/doc/pyclaw/state.rst
+++ b/doc/pyclaw/state.rst
@@ -23,13 +23,13 @@ are interested in the geometry of the local state you can find it through the
 Serial :class:`pyclaw.state.State`
 ==================================
    
-.. autoclass:: pyclaw.state.State
+.. autoclass:: clawpack.pyclaw.state.State
    :members:
    :member-order: groupwise
 
 Parallel :class:`petclaw.state.State`
 ===========================================
 
-.. autoclass:: petclaw.state.State
+.. autoclass:: clawpack.petclaw.state.State
    :members:
    :member-order: groupwise

--- a/doc/pyclaw/util.rst
+++ b/doc/pyclaw/util.rst
@@ -9,5 +9,5 @@ Pyclaw Utility Module
 :mod:`pyclaw.util`
 =============================
 
-.. automodule:: pyclaw.util
+.. automodule:: clawpack.pyclaw.util
    :members:


### PR DESCRIPTION
This fixes everything brought up by @MathematicianVogt  in https://github.com/clawpack/clawpack/issues/119, as well as all other instances I could find.  The problem was that back when we put pyclaw under clawpack, we didn't fix all the autodoc paths to start with clawpack.