### PR TITLE
Update instructions for conda installation.

### DIFF
--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -135,18 +135,14 @@ See :ref:`setup_dev` for instructions.
 Install using conda (does not require a Fortran compiler)
 =========================================================
 
-.. warning:: This is currently under development and not extensively tested.
-
-.. warning:: Not yet updated to 5.5.0.
-
 You can install PyClaw and VisClaw only (without AMRClaw, GeoClaw, or Classic)
 via the `conda package manager <http://conda.pydata.org/docs/index.html>`_.
 Conda binaries are available for Mac OS X and Ubuntu Linux
-(may work on other flavors of Linux).
+(may work on other flavors of Linux), using Python 2.7 or Python 3.6.
 
 From a terminal, simply do::
 
-    conda install -c clawpack -c conda-forge clawpack=5.4.1
+    conda install -c clawpack -c conda-forge
 
 You might want to consider first creating a separate `conda environment
 <http://conda.pydata.org/docs/using/envs.html>`_ if you want to separate

--- a/doc/pyclaw/index.rst
+++ b/doc/pyclaw/index.rst
@@ -19,7 +19,7 @@ This requires that you have a Fortran compiler installed.
 Alternatively, if you use `Anaconda <https://store.continuum.io/cshop/anaconda/>`_ or 
 `Conda <https://pypi.python.org/pypi/conda>`_, you can::
 
-    conda install -c clawpack -c conda-forge clawpack=5.4.1
+    conda install -c clawpack -c conda-forge
 
 This option will also install optional dependencies including PETSc and HDF5,
 which are useful for large-scale parallel runs.  It does not require that you


### PR DESCRIPTION
Remove warnings since this is now a preferred way of installing PyClaw and works for the latest version of Clawpack, with Python 2 or Python 3.