### PR TITLE
Update instructions for installing with Conda.

### DIFF
--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -135,18 +135,14 @@ See :ref:`setup_dev` for instructions.
 Install using conda (does not require a Fortran compiler)
 =========================================================
 
-.. warning:: This is currently under development and not extensively tested.
-
-.. warning:: Not yet updated to 5.5.0.
-
 You can install PyClaw and VisClaw only (without AMRClaw, GeoClaw, or Classic)
 via the `conda package manager <http://conda.pydata.org/docs/index.html>`_.
 Conda binaries are available for Mac OS X and Ubuntu Linux
-(may work on other flavors of Linux).
+(may work on other flavors of Linux), using Python 2.7 or 3.6.
 
 From a terminal, simply do::
 
-    conda install -c clawpack -c conda-forge clawpack=5.4.1
+    conda install -c clawpack -c conda-forge clawpack
 
 You might want to consider first creating a separate `conda environment
 <http://conda.pydata.org/docs/using/envs.html>`_ if you want to separate

--- a/doc/pyclaw/index.rst
+++ b/doc/pyclaw/index.rst
@@ -15,15 +15,16 @@ Just do this::
 
     pip install clawpack
 
-This requires that you have a Fortran compiler installed.
+Installing with pip requires that you have a Fortran compiler installed.
+
 Alternatively, if you use `Anaconda <https://store.continuum.io/cshop/anaconda/>`_ or 
 `Conda <https://pypi.python.org/pypi/conda>`_, you can::
 
-    conda install -c clawpack -c conda-forge clawpack=5.4.1
+    conda install -c clawpack -c conda-forge clawpack
 
 This option will also install optional dependencies including PETSc and HDF5,
-which are useful for large-scale parallel runs.  It does not require that you
-have a Fortran compiler.
+which are useful for large-scale parallel runs.  Installing with Conda does not
+require that you have a Fortran compiler.
 
 Examples
 --------


### PR DESCRIPTION
Remove warnings.
No need to specify version.