### PR TITLE
No more symlinks or setting PYTHONPATH

### DIFF
--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -71,39 +71,6 @@ plan to use Classic, AMRClaw, or GeoClaw continue with :ref:`setenv` to
 set the environment variables `CLAW` and `FC`.
 
 
-.. _install_no-pyclaw:
-
-Install other packages without compiling PyClaw
-================================================
-If you get errors in the compilation step when using `pip install` or
-`python setup.py install`, check :ref:`trouble_installation`. 
-If your problem is not addressed there, please `let us know <claw-users@googlegroups.com>`_
-or `raise an issue <https://github.com/clawpack/clawpack/issues>`_.
-You can still use the Fortran codes (AMRClaw, GeoClaw, and Classic) by doing
-the following.  
-
-First, download a tarfile of the latest release as described above in
-the section :ref:`installing_tarfile`.  
-
-Next :ref:`setenv`, including `CLAW`, `FC`, and  `PYTHONPATH`.
-
-Then you should be able to do::
-
-    cd $CLAW   # assuming this environment variable was properly set
-    python setup.py symlink-only
-
-This will create some symbolic links in the `$CLAW/clawpack` 
-subdirectory of your top level Clawpack directory, but does not compile code
-or put anything in your site-packages.
-In Python you should now be able to do the following, for example::
-
-    >>> from clawpack import visclaw
-
-If not then either your `$PYTHONPATH` environment variable is not set
-properly or the required symbolic links were not created.
-See :ref:`setenv` for more information, and :ref:`python_path` if you are
-having problems with importing Python modules.
-
 Next go to :ref:`first_run`.
 
 .. _install_pyclaw_parallel:

--- a/doc/installing_pip.rst
+++ b/doc/installing_pip.rst
@@ -75,11 +75,11 @@ Quick Installation of only PyClaw
 If you only want to use PyClaw (and associated Python
 tools, e.g. VisClaw for visualization), they you could do::
 
-    pip install clawpack
+    pip install --user clawpack
 
 or, more specifically, ::
 
-    pip install clawpack==v5.4.1
+    pip install --user clawpack==v5.5.0
 
 However, if you think you might want to use the Fortran packages as well
 (Classic, AMRClaw, GeoClaw) and/or want easier access to the Python source
@@ -153,9 +153,7 @@ here are some tips:
   finding these files.
 
 - If you wish to point to a different version of the Clawpack Python tools, 
-  you need to rerun `pip install`.  Or you may need to remove the path from the
-  `easy-install.pth` file if you want to switch to using `PYTHONPATH`.
-  See :ref:`python_path` for more information.
+  you need to rerun `pip install`.
 
 - If you get a Fortran error message when installing, see
   :ref:`trouble_f2py`.

--- a/doc/setenv.rst
+++ b/doc/setenv.rst
@@ -38,29 +38,3 @@ should list the top level directory, and report for example::
     README.md       riemann/        pyclaw/
     amrclaw/        setup.py        clawutil/       
     geoclaw/        visclaw/        classic/        
- 
-PYTHONPATH
-----------
-
-If you installed from a tarfile or using a `git clone` without using `pip`, then
-you will need to set the `PYTHONPATH` variable in order for the Python codes to be
-found.  This is not necessary if you used `pip` to install (see
-:ref:`installing_pip`).  
-
-See :ref:`python_path` for more about Python paths and this environment
-variable.
-
-In the `bash` shell, for example, this path can be set via::
-
-    export PYTHONPATH=/path/to/clawpack:$PYTHONPATH
-
-Note that this places this new path at the front of any existing path, and will be
-searched before other directories where you might have a different version of
-Clawpack, e.g. if you have used `pip` to install a different version and there is
-a path in a `site-packages/easy-install.pth` file.  
-
-Using `PYTHONPATH` can also be useful if you want to use
-different versions of Clawpack in different shells, 
-e.g. when dual-debugging or for different projects.
-
-


### PR DESCRIPTION
This updates our installation instructions to reflect https://github.com/clawpack/clawpack/pull/141 and https://github.com/clawpack/clawpack/issues/138.  Specifically, there is no longer an option to just create symlinks (since our installation process doesn't create symlinks anymore anyway) and we no longer instruct users to set PYTHONPATH.

I also added the `--user` option everywhere that we suggest using `pip install`.