### PR TITLE
Update installation instructions to recommend pip over PYTHONPATH

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -42,7 +42,7 @@ Releases:
 * :ref:`release_5_4_1`  -- June 28, 2017
   `[DOI 10.5281/zenodo.820730] <https://doi.org/10.5281/zenodo.820730>`_
 * :ref:`release_5_5_0`  -- August 28, 2018
-  `[DOI 10.5281/zenodo.1405834]`
+  `[DOI 10.5281/zenodo.1405834] <https://doi.org/10.5281/zenodo.1405834>`_
 * :ref:`changes_to_master`
 
 

--- a/doc/developers.rst
+++ b/doc/developers.rst
@@ -57,7 +57,8 @@ You can create a read-only development version of Clawpack via::
 
     git clone git://github.com/clawpack/clawpack.git
     cd clawpack
-    python setup.py git-dev
+    git submodule init
+    git submodule update
 
 This downloads the following clawpack modules as subrepositories checked out at
 specific commits (as opposed to the tip of a branch). 
@@ -273,7 +274,7 @@ anything:
     if you have modified any Fortran code, you need to recompile::
 
         cd clawpack/
-        pip install -e .
+        pip install --user -e .
 
     Then run the tests::
 

--- a/doc/first_run_fortran.rst
+++ b/doc/first_run_fortran.rst
@@ -14,6 +14,9 @@ As a first test of the Fortran code, try the following::
     cd $CLAW/classic/tests
     nosetests -sv
 
+(You may need to install `nose <https://nose.readthedocs.io/en/latest/>`_
+if `nosetests` is not on your system.)
+
 This will run several tests and compare a few numbers from the solution with
 archived results.  The tests should run in a few seconds and 
 you should see output similar to this::

--- a/doc/first_run_pyclaw.rst
+++ b/doc/first_run_pyclaw.rst
@@ -9,7 +9,9 @@ installation as follows (starting from your `clawpack` directory)::
     cd pyclaw/examples
     nosetests
 
-This should return 'OK'.
+This should return 'OK'.  
+(You may need to install `nose <https://nose.readthedocs.io/en/latest/>`_
+if `nosetests` is not on your system.)
 
 
 Running an example

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -71,39 +71,6 @@ plan to use Classic, AMRClaw, or GeoClaw continue with :ref:`setenv` to
 set the environment variables `CLAW` and `FC`.
 
 
-.. _install_no-pyclaw:
-
-Install other packages without compiling PyClaw
-================================================
-If you get errors in the compilation step when using `pip install` or
-`python setup.py install`, check :ref:`trouble_installation`. 
-If your problem is not addressed there, please `let us know <claw-users@googlegroups.com>`_
-or `raise an issue <https://github.com/clawpack/clawpack/issues>`_.
-You can still use the Fortran codes (AMRClaw, GeoClaw, and Classic) by doing
-the following.  
-
-First, download a tarfile of the latest release as described above in
-the section :ref:`installing_tarfile`.  
-
-Next :ref:`setenv`, including `CLAW`, `FC`, and  `PYTHONPATH`.
-
-Then you should be able to do::
-
-    cd $CLAW   # assuming this environment variable was properly set
-    python setup.py symlink-only
-
-This will create some symbolic links in the `$CLAW/clawpack` 
-subdirectory of your top level Clawpack directory, but does not compile code
-or put anything in your site-packages.
-In Python you should now be able to do the following, for example::
-
-    >>> from clawpack import visclaw
-
-If not then either your `$PYTHONPATH` environment variable is not set
-properly or the required symbolic links were not created.
-See :ref:`setenv` for more information, and :ref:`python_path` if you are
-having problems with importing Python modules.
-
 Next go to :ref:`first_run`.
 
 .. _install_pyclaw_parallel:

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -3,109 +3,130 @@
 .. _installing:
 
 **************************************
-Installation options
+Installing Clawpack
 **************************************
 
-Please `register <http://depts.washington.edu/clawpack/register/index.html>`_
+See also:
+
+* :ref:`clawpack_packages`
+* :ref:`changes`
+* :ref:`previous`
+* :ref:`trouble_installation`
+
+**Register:** Please `register <http://depts.washington.edu/clawpack/register/index.html>`_
 if you have not already done so.  This is very useful in helping
 us track the extent of usage, and important to the :ref:`funding` agencies
 who support this work.  Please also see :ref:`citing`.
 
-If you will only use PyClaw and/or VisClaw, skip to :ref:`pyclaw_install` for
-the simplest installation instructions.
-
-Instead of installing Clawpack and all its dependencies, another alternative
-is :ref:`docker_image`.
-
-For installation of older versions, see :ref:`previous`.
-
 **Prerequisites:** Before installing, check that you have the :ref:`prereqs`.
 
+**Environment variables:**  
+If you are using the Fortran versions in Classic, AMRClaw, or GeoClaw
+then after installing you also need to set the `CLAW` environment variable,
+and perhaps also the Fortran compiler variable `FC`.
+For example (in a bash shell)::
 
-Install using pip
+    export CLAW=/full/path/to/clawpack  # to top level clawpack directory
+    export FC=gfortran                  # or other preferred Fortran compiler
+
+See :ref:`setenv` for more information.   
+
+**Python path:**
+Below we suggest using `pip install` to set up your Python path to point to
+the desired version of Clawpack.  As long as the top level `clawpack`
+directory is on your path, you should be able to import the necessary
+modules in Python.  Instead of pip, you can also set the `PYTHONPATH`
+environment variable to point to a particular version of Clawpack,
+but this is `not recommended <https://orbifold.xyz/pythonpath.html>`_.
+See :ref:`python_path` for more details and tips on sorting out your path.
+
+**Components:**
+See :ref:`clawpack_components` for a list of what is generally included
+under the top level `clawpack` directory when using any of the approaches below.
+(And what is not included, e.g. the :ref:`apps`.)
+
+.. _installing_options:
+
+Installation Options
 =====================================
 
-This is the simplest approach, particularly if you already 
-use `pip` for other purposes; see :ref:`installing_pip`.  
+*Installing* Clawpack requires downloading some version and then setting
+paths so that Python import statements (and possibly Fortran Makefiles) find
+the desired version.  Before installing, read about environment
+variables and Python path above if you haven't already.
 
-Unfortunately if this doesn't work it may be hard to debug what went wrong.
+Installing with `pip` also compiles Riemann solvers written in Fortran for
+use in PyClaw.  If you get a Fortran error message when installing, see
+:ref:`trouble_f2py`.  See also :ref:`prereqs_fortran`.
+
+
+.. _installing_pipintro:
+
+pip install
+-----------
+
+The recommended approach is to use `pip install`.  You can download
+and install with a single command, and you can also use `pip` to
+switch to a different version of Clawpack (i.e. to modify your
+Python path) if you have reason to have multiple versions on your
+computer.  
+
+Depending on your needs, if you only want to use PyClaw it may be as simple as::
+
+        pip install clawpack
+
+but first see :ref:`installing_pip` for more discussion and instructions,
+since we recommend a more complicated version of this command for most purposes.
 
 .. _installing_tarfile:
 
-Install from a tarfile
-=====================================
+tar file
+--------
 
-Download a tar file of the latest release:
+You can download the most recent (or certain previous versions) of Clawpack
+as a tar file. After untarring this, you can use `pip install` (and set `CLAW` 
+if necessary) to point to this version.
 
-* `https://github.com/clawpack/clawpack/files/2330639/clawpack-v5.5.0.tar.gz
-  <https://github.com/clawpack/clawpack/files/2330639/clawpack-v5.5.0.tar.gz>`_
-* :ref:`previous`
-* :ref:`changes`
+    - Most recent: `https://github.com/clawpack/clawpack/files/2330639/clawpack-v5.5.0.tar.gz
+      <https://github.com/clawpack/clawpack/files/2330639/clawpack-v5.5.0.tar.gz>`_
+    - :ref:`previous`  (also lists DOIs for recent versions, useful for
+      :ref:`citing`)
 
+After downloading a tar file you can do, e.g. ::
 
-See :ref:`clawpack_components` for a list of what's included in this tar file.
-
-Save this tar file in the directory where you want the top level of the
-clawpack tree to reside.  Then untar using the command::   
-
-    tar -xzvf clawpack-v5.5.0.tar.gz
-
-Then move into the top level directory::
-
+    tar -xzf clawpack-v5.5.0.tar.gz
     cd clawpack-v5.5.0
-
-Next install the Python components of Clawpack (but read the next two
-paragraphs first)::
-
-    python setup.py install
-
-This will compile a lot of Fortran code using `f2py` for PyClaw and may
-produce a lot of output.
-
-If you get compilation errors in this step, or if you do not plan to use
-PyClaw, you can still use the
-Classic, AMRClaw, and GeoClaw version; see :ref:`install_no-pyclaw` below.
-
-If you only plan to use PyClaw, jump to :ref:`first_run`.  If you
-plan to use Classic, AMRClaw, or GeoClaw continue with :ref:`setenv` to
-set the environment variables `CLAW` and `FC`.
-
-
-Next go to :ref:`first_run`.
-
-.. _install_pyclaw_parallel:
-
-Install only PyClaw (for running in parallel)
-================================================
-First, install PyClaw as explained above.  Then see the install instructions
-for :ref:`parallel`.
-
-Alternatively, you may use the following shell scripts (assembled by Damian San Roman)
-to install everything:
-
-* Linux machine or Beowulf Cluster: https://gist.github.com/sanromd/9112666
-* Mac OS X: https://gist.github.com/sanromd/10374134
-
-
+    pip install --user -e .   # note trailing dot indicating "this directory"
+    export CLAW=/full/path/to/clawpack-v5.5.0
+    
 .. _install_dev:
 
-Install the latest development version
-================================================
+git clone
+---------
 
-The development version of Clawpack can be obtained by cloning 
-`<https://github.com/clawpack>`_.  This is advised for those who want to help
-develop Clawpack or to have the most recent bleeding edge version.
-See :ref:`setup_dev` for instructions.
+You can clone the git repositories from `<https://github.com/clawpack>`_.  
+This is particularly useful if you
+want the latest development version or a branch that is not in a release yet,
+and/or if you plan to contribute to the code yourself via a pull request.
+See :ref:`developers` for more details, but the basic commands are::
+
+    git clone git://github.com/clawpack/clawpack.git
+    cd clawpack
+    git submodule init      # for repositories pyclaw, clawutil, visclaw, etc.
+    git submodule update    # clones all the submodule repositories
+    pip install --user -e . # note trailing dot indicating "this directory"
+    export CLAW=/full/path/to/clawpack
 
 .. _installing_conda:
 
-Install using conda (does not require a Fortran compiler)
-=========================================================
+Using conda (does not require a Fortran compiler)
+----------------------------------------------------------
 
 You can install PyClaw and VisClaw only (without AMRClaw, GeoClaw, or Classic)
 via the `conda package manager <http://conda.pydata.org/docs/index.html>`_.
 Conda binaries are available for Mac OS X and Ubuntu Linux
 (may work on other flavors of Linux), using Python 2.7 or 3.6.
+See https://github.com/clawpack/conda-recipes.
 
 From a terminal, simply do::
 
@@ -115,18 +136,28 @@ You might want to consider first creating a separate `conda environment
 <http://conda.pydata.org/docs/using/envs.html>`_ if you want to separate
 Clawpack and its dependencies from other versions of Python code. 
 
-See https://github.com/clawpack/conda-recipes.
 
+.. _installing_docker:
+    
+Docker
+------
 
-.. _install_alternatives:
+Instead of installing Clawpack and all its dependencies, another alternative
+is :ref:`docker_image`.  The Docker image already contains not only Clawpack
+but also all the :ref:`prereqs`.
 
-Running Clawpack on a VM 
-========================
+.. _install_pyclaw_parallel:
 
-See :ref:`docker_image` to use Docker.
+Installing PyClaw for parallel processing with PETSc
+----------------------------------------------------
 
-Other VM versions are currently out of date. Check back for updates to
-this page.
+First, install Clawpack.  Then see the install instructions for :ref:`parallel`.
+
+Alternatively, you may use the following shell scripts (assembled by Damian San Roman)
+to install everything:
+
+ -  Linux machine or Beowulf Cluster: https://gist.github.com/sanromd/9112666
+ -  Mac OS X: https://gist.github.com/sanromd/10374134
 
 
 

--- a/doc/installing_pip.rst
+++ b/doc/installing_pip.rst
@@ -4,9 +4,6 @@
 Installation instructions (pip)
 **************************************
 
-These instructions are a work in progress.  Suggestions welcome 
-(`raise an issue <https://github.com/clawpack/doc/issues>`_).
-
 For other installation options, see :ref:`installing`.
 
 See also:
@@ -16,13 +13,24 @@ See also:
 * :ref:`previous`
 * :ref:`trouble_installation`
 
-Please `register <http://depts.washington.edu/clawpack/register/index.html>`_
+**Register:** Please `register <http://depts.washington.edu/clawpack/register/index.html>`_
 if you have not already done so.  This is very useful in helping
 us track the extent of usage, and important to the :ref:`funding` agencies
 who support this work.
 
 
 **Prerequisites:** Before installing, check that you have the :ref:`prereqs`.
+
+*Installing* Clawpack requires downloading some version and then setting
+paths so that Python import statements (and possibly Fortran Makefiles) find
+the desired version.  `pip` can be used to reset Python paths as well as to
+download a new version of Clawpack and set the path appropriately.  See
+:ref:`python_path` for more information.
+
+Installing with `pip` also compiles Riemann solvers written in Fortran for
+use in PyClaw.  If you get a Fortran error message when installing, see
+:ref:`trouble_f2py`.
+
 
 .. _install_quick_all:
 
@@ -70,7 +78,6 @@ having problems with importing Python modules.
 Quick Installation of only PyClaw
 =====================================
 
-.. warning:: Not yet updated to 5.5.0.
 
 If you only want to use PyClaw (and associated Python
 tools, e.g. VisClaw for visualization), they you could do::
@@ -96,10 +103,10 @@ started:
 - :ref:`first_run_pyclaw`
 - :ref:`first_run_fortran`
 
-Notes on using pip to install
------------------------------
+Using pip to install a different version
+-----------------------------------------
 
-This approach clones Git repositories from
+Using `pip` to download and install actually clones Git repositories from
 https://github.com/clawpack/clawpack.  If you are comfortable with
 Git you can use the same top repository to update Clawpack or switch
 to other versions.  However, if you have made any changes to files
@@ -114,10 +121,25 @@ Instead, you can always install another branch by doing a new
         git+https://github.com/clawpack/clawpack.git@$CLAW_VERSION#egg=clawpack-$CLAW_VERSION
     export CLAW=$HOME/clawpack_src/clawpack-$CLAW_VERSION
 
-We also suggest that if you want to experiment extensively with examples or
+If this version doesn't already exist on your computer then it will clone
+the necessary repositories.
+
+If you already have a different version of Clawpack in some directory 
+obtained by any means (e.g. from a tarfile), then you can set the paths
+properly via::
+
+    export CLAW=/full/path/to/desired/version/of/clawpack
+    cd $CLAW
+    pip install --user -e .   # note trailing dot indicating "this directory"
+
+
+Experimenting with code in the examples directories
+---------------------------------------------------
+
+We suggest that if you want to experiment extensively with examples or
 modify an example to solve your own problem, you first copy a directory out
 of the source code tree to a different location, in order to minimize
-confusion if you later want to update to a newer version of clawpack.  See
+confusion if you later want to update to a different version of clawpack.  See
 :ref:`newapp` for more details.
 
 If you want to check out the `master` branch of the clawpack repositories or
@@ -135,22 +157,16 @@ here are some tips:
   remaining in the directory `$CLAW`, which includes all the Fortran packages as
   well as Python source.
 
-- Earlier versions of the installation instructions required setting the
-  environment variable `PYTHONPATH`.  This is not necessary or desirable if
-  you use the `pip install` option, which instead
-  creates or modifies a file `easy-install.pth` that is
-  found in the Python `site-packages` directory (see :ref:`python_path`).
-  The path to the clawpack source is added to this file and hence to the
-  search path for Python.  This allows importing Clawpack modules, but note
-  that directories specified here are searched before those specified by
-  the environment variable `PYTHONPATH`.  
-
 - When the `--user` flag is omitted, the `pip install` will modify a
   system-wide file `easy-install.pth` to add the path. This requires
   root permission.  When the `--user` flag is used, this path will
   instead be added to an `easy-install.pth` file that is within
   your user directory structure. See :ref:`python_path` for information on
   finding these files.
+
+- If you use `pip` to install or switch versions then you should **not** set
+  the environment variable `PYTHONPATH`.  See :ref:`python_path` for more
+  information.
 
 - If you wish to point to a different version of the Clawpack Python tools, 
   you need to rerun `pip install`.

--- a/doc/installing_pip.rst
+++ b/doc/installing_pip.rst
@@ -75,11 +75,11 @@ Quick Installation of only PyClaw
 If you only want to use PyClaw (and associated Python
 tools, e.g. VisClaw for visualization), they you could do::
 
-    pip install clawpack
+    pip install --user clawpack
 
 or, more specifically, ::
 
-    pip install clawpack==v5.4.1
+    pip install --user clawpack==v5.5.0
 
 However, if you think you might want to use the Fortran packages as well
 (Classic, AMRClaw, GeoClaw) and/or want easier access to the Python source
@@ -153,9 +153,7 @@ here are some tips:
   finding these files.
 
 - If you wish to point to a different version of the Clawpack Python tools, 
-  you need to rerun `pip install`.  Or you may need to remove the path from the
-  `easy-install.pth` file if you want to switch to using `PYTHONPATH`.
-  See :ref:`python_path` for more information.
+  you need to rerun `pip install`.
 
 - If you get a Fortran error message when installing, see
   :ref:`trouble_f2py`.

--- a/doc/packages.rst
+++ b/doc/packages.rst
@@ -25,8 +25,10 @@ packages and rely on Makefiles and environment variables.  Problems are
 specified partially through Python scripts at run time (`setrun.py`) and partially
 through custom Fortran code at compile time (to set initial conditions, for instance).
 
-With PyClaw, problems are specified entirely at run time through Python script files, or
-interactively (e.g., in IPython).  Typically, the user does not need to
+With PyClaw, problems are specified entirely at run time through 
+Python script files, or
+interactively (e.g., in IPython or Jupyter notebooks).  
+Typically, the user does not need to
 write any Fortran code (though custom routines can be written in Fortran
 when necessary for performance reasons).
 PyClaw uses much of the same library of Fortran code, but that code is

--- a/doc/python_path.rst
+++ b/doc/python_path.rst
@@ -1,8 +1,10 @@
 :orphan:
+
 .. _python_path:
 
 Python path
 ===========
+
 
 When using PyClaw or other Python tools from Clawpack (e.g. the
 visualization tools in VisClaw or :ref:`topotools` from GeoClaw), you need
@@ -26,6 +28,29 @@ The script `$CLAW/clawutil/src/python/clawutil/whichclaw.py` may be useful in
 debugging paths.  It prints out information on how various paths and environment
 variables are set.  (Available starting in Version 5.4.0.)
 
+Sample output::
+
+    $ python $CLAW/clawutil/src/python/clawutil/whichclaw.py
+
+    `import clawpack` imports from:
+        /Users/rjl/clawpack_src/clawpack-v5.5.0
+
+    The CLAW environment variable is set to: 
+        /Users/rjl/D/clawpack-v5.5.0
+    The PYTHONPATH environment variable is not set
+
+    The following directories on sys.path might contain clawpack,
+    and are searched in this order:
+        /Users/rjl/clawpack_src/clawpack-v5.5.0
+
+    The following easy-install.pth files list clawpack:
+        /Users/rjl/Library/Python/2.7/lib/python/site-packages/easy-install.pth
+            (points to /Users/rjl/clawpack_src/clawpack-v5.5.0)
+
+Beware if there seems to be a conflict (e.g. between where the `CLAW` 
+environment variable points and where Python imports from).
+See below for more about `sys.path` and `easy-install.pth` files.
+
 Which version was imported?
 ---------------------------
 
@@ -36,10 +61,10 @@ Try the following in a Python (or IPython) shell::
 
 This should print out something like::
 
-    '/Users/rjl/clawpack_src/clawpack-v5.3.1/clawpack/__init__.py'
+    '/Users/rjl/clawpack_src/clawpack-v5.5.0/clawpack/__init__.py'
 
 This shows where clawpack is being imported from.  In this case the
-directory `/Users/rjl/clawpack_src/clawpack-v5.3.1` is the directory
+directory `/Users/rjl/clawpack_src/clawpack-v5.5.0` is the directory
 normally referred to as `$CLAW` in this documentation.  Within this
 directory, there is a subdirectory `$CLAW/clawpack` that contains a file
 `__init__.py`, which is a standard Python way of indicating that the files
@@ -52,25 +77,28 @@ this path looking for the first one that contains a subdirectory named
 `clawpack` containing a file `__init__.py`, (or a file named `clawpack.py`,
 but in this case it should find the `$CLAW/clawpack` directory).  
 
-The directory `$CLAW/clawpack` also contains symbolic links to other
-directories within the Clawpack repository hierarchy that contain
-other Python modules.  This allows you to do, for example::
+.. warning :: Up to version 5.5.0, 
+   the directory `$CLAW/clawpack` also contains symbolic links to other
+   directories within the Clawpack repository hierarchy that contain
+   other Python modules.  This allows you to do, for example::
 
     >>> from clawpack import pyclaw
     >>> pyclaw.__file__
 
-    '/Users/rjl/clawpack_src/clawpack-v5.3.1/clawpack/pyclaw/__init__.py'
+    '/Users/rjl/clawpack_src/clawpack-v5.5.0/clawpack/pyclaw/__init__.py'
 
-If you examine this in bash, e.g. via::
+Starting in Version 5.6.0, symbolic links in `$CLAW/clawpack` 
+have been eliminated.
+Instead `$CLAW/clawpack/__init__.py` includes a dictionary of subpackages with 
+the relative path indicated in this file::
 
-    $ ls -l $CLAW/clawpack/pyclaw
+    >>> import clawpack
+    >>> clawpack._subpackages
+    {'forestclaw': 'pyclaw/src', 'amrclaw': 'amrclaw/src/python', 'riemann': 'riemann', 
+     'pyclaw': 'pyclaw/src', 'classic': 'classic/src/python', 'visclaw': 'visclaw/src/python', 
+    'clawutil': 'clawutil/src/python', 'petclaw': 'pyclaw/src', 'geoclaw': 'geoclaw/src/python'}
+  
 
-you should find that this is a symbolic link to the directory
-`$CLAW/pyclaw/src/pyclaw`, which is where you would find the actual source
-code for things in the `pyclaw` package.
-
-These symbolic links are set up when you install clawpack (using `pip
-install` or more explicitly using e.g. `python setup.py symlink-only`).
 
 **Example:** Suppose you want to examine the Python code for the `Iplotclaw`
 module of VisClaw (see :ref:`plotting_Iplotclaw`).  You can figure out where
@@ -137,14 +165,33 @@ path to this via::
 PYTHONPATH
 ----------
 
+.. warning :: Setting the environment variable `PYTHONPATH` is generally
+   considered bad practice in the Python community
+   and can lead to problems, see for example
+   `PYTHONPATH Considered Harmful <https://orbifold.xyz/pythonpath.html>`_.
+
 If you have an environment variable `PYTHONPATH` set, the paths specified
 here may be searched before or after what is specified in the users'
 `site-packages/easy-install.pth`, depending on how you set `PYTHONPATH`.  
+See also 
+https://docs.python.org/3/using/cmdline.html#environment-variables.
+Hence trying to use `PYTHONPATH` if you have also used pip to install a
+different version of Clawpack can lead to confusion.
 
-To see if this is set, in the bash shell you can do::
+To see if this environment variable is set, in the bash shell you can do::
 
      $ echo $PYTHONPATH
 
+or use the :ref:`whichclaw` utility to report this, along with any other
+possibly conflicting `easy-install.pth` files.
+
 See :ref:`setenv` for information on setting environment variables.
 
+In spite of the possible drawbacks, some Clawpack developers often
+use `PYTHONPATH` to switch versions without difficulty.  If you do
+wish to use it, you should set `PYTHONPATH` to point to the top
+level of the clawpack directory for the code you wish to use.
+Then use the :ref:`whichclaw` utility to check that this is where Clawpack
+is imported from, and there is not a `easy-install.pth` that points to a
+different location.
 

--- a/doc/regression.rst
+++ b/doc/regression.rst
@@ -25,6 +25,8 @@ Regression tests can be performed via::
     nosetests
 
 For more details, see :ref:`pyclaw_testing`.
+(You may need to install `nose <https://nose.readthedocs.io/en/latest/>`_
+if `nosetests` is not on your system.)
 
 Fortran codes
 -------------

--- a/doc/setenv.rst
+++ b/doc/setenv.rst
@@ -38,29 +38,3 @@ should list the top level directory, and report for example::
     README.md       riemann/        pyclaw/
     amrclaw/        setup.py        clawutil/       
     geoclaw/        visclaw/        classic/        
- 
-PYTHONPATH
-----------
-
-If you installed from a tarfile or using a `git clone` without using `pip`, then
-you will need to set the `PYTHONPATH` variable in order for the Python codes to be
-found.  This is not necessary if you used `pip` to install (see
-:ref:`installing_pip`).  
-
-See :ref:`python_path` for more about Python paths and this environment
-variable.
-
-In the `bash` shell, for example, this path can be set via::
-
-    export PYTHONPATH=/path/to/clawpack:$PYTHONPATH
-
-Note that this places this new path at the front of any existing path, and will be
-searched before other directories where you might have a different version of
-Clawpack, e.g. if you have used `pip` to install a different version and there is
-a path in a `site-packages/easy-install.pth` file.  
-
-Using `PYTHONPATH` can also be useful if you want to use
-different versions of Clawpack in different shells, 
-e.g. when dual-debugging or for different projects.
-
-

--- a/doc/setenv.rst
+++ b/doc/setenv.rst
@@ -13,7 +13,7 @@ environment variable `CLAW` to point to the top level of clawpack tree
 (there is no need to perform this step if you will only use PyClaw).
 In the bash shell these can be set via::
 
-    export CLAW=/full/path/to/top/level
+    export CLAW=/full/path/to/clawpack  # to top level clawpack directory
 
 
 FC
@@ -38,3 +38,10 @@ should list the top level directory, and report for example::
     README.md       riemann/        pyclaw/
     amrclaw/        setup.py        clawutil/       
     geoclaw/        visclaw/        classic/        
+
+PYTHONPATH
+----------
+
+We do not recommend setting this environment variable.  See
+:ref:`python_path` for more information.  Instead we recommend using `pip
+install` to set the Python path appropriately, see :ref:`installing_pip`.

--- a/doc/testing.rst
+++ b/doc/testing.rst
@@ -15,6 +15,8 @@ installation as follows (starting from your `clawpack` directory)::
     nosetests
 
 This should return 'OK'.
+(You may need to install `nose <https://nose.readthedocs.io/en/latest/>`_
+if `nosetests` is not on your system.)
 
 Classic
 -------

--- a/doc/trouble.rst
+++ b/doc/trouble.rst
@@ -44,10 +44,22 @@ Then to install using a different compiler, do e.g.::
 
 You may replace ``gfortran`` with the compiler you wish to use.
 
+.. _trouble_fc:
+
+Trouble compiling Fortran code at the command line
+-----------------------------------------------------
+
+The packages Classic, AMRClaw, and GeoClaw all require compiling Fortran
+code in the process of running an example.  This is typically done with the
+`make .exe` command in an example or application directory that contains a
+:ref:`makefiles`.  Even if you don't do this explicitly, due to dependency
+checking in the Makefile the code will be compiled if necessary if you do
+`make .output`, or `make .plots` (or `make all`).
+
 .. _trouble_makeexe:
 
 Trouble running "make .exe"
-+++++++++++++++++++++++++++
+-----------------------------------------------------
 
 If the code does not compile, check the following:
 


### PR DESCRIPTION
Replaces #199. 

Many updates and rearrangement of instructions to suggest using pip.
Still mentions `PYTHONPATH` but warns against using it.

I also cleaned up some other out-of-date discussions, added more examples, and tried to make it easier to sort out the different options.