### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -36,9 +36,9 @@ Releases:
 * :ref:`release_5_2_2`  -- October 28, 2014
 * :ref:`release_5_3_0`  -- May 21, 2015
 * :ref:`release_5_3_1`  -- November 10, 2015
-  `[DOI 10.5281/zenodo.50982] <http://dx.doi.org/10.5281/zenodo.50982>`_
+  `[DOI 10.5281/zenodo.50982] <https://doi.org/10.5281/zenodo.50982>`_
 * :ref:`release_5_4_0`  -- January 17, 2017
-  `[DOI 10.5281/zenodo.262111] <http://dx.doi.org/10.5281/zenodo.262111>`_
+  `[DOI 10.5281/zenodo.262111] <https://doi.org/10.5281/zenodo.262111>`_
 * :ref:`release_5_4_1`  -- June 28, 2017
   `[DOI 10.5281/zenodo.820730] <https://doi.org/10.5281/zenodo.820730>`_
 * :ref:`release_5_5_0`  -- August 28, 2018

--- a/doc/previous.rst
+++ b/doc/previous.rst
@@ -14,8 +14,8 @@ Previous versions of Clawpack
 
     * Version 5.4.1: `10.5281/zenodo.1405834 <https://doi.org/10.5281/zenodo.1405834>`_
     * Version 5.4.1: `10.5281/zenodo.820730 <https://doi.org/10.5281/zenodo.820730>`_
-    * Version 5.4.0: `10.5281/zenodo.262111 <http://dx.doi.org/10.5281/zenodo.262111>`_
-    * Version 5.3.1: `10.5281/zenodo.50982 <http://dx.doi.org/10.5281/zenodo.50982>`_
+    * Version 5.4.0: `10.5281/zenodo.262111 <https://doi.org/10.5281/zenodo.262111>`_
+    * Version 5.3.1: `10.5281/zenodo.50982 <https://doi.org/10.5281/zenodo.50982>`_
 
   
 

--- a/papers/clawpack-5x/paper.bib
+++ b/papers/clawpack-5x/paper.bib
@@ -31,7 +31,7 @@ uri = {\url{papers3://publication/uuid/nr--D401BE49-96E5-4F7A-866E-DA2C0375C258}
    eid = ,
    pages = "21-29",
    url = "http://scitation.aip.org/content/aip/journal/cise/9/3/10.1109/MCSE.2007.53",
-   doi = "http://dx.doi.org/10.1109/MCSE.2007.53" 
+   doi = "https://doi.org/10.1109/MCSE.2007.53" 
 }
 
 
@@ -885,5 +885,5 @@ Propagation Problems",
   month        = nov,
   year         = 2015,
   doi          = {10.5281/zenodo.50982},
-  url          = {http://dx.doi.org/10.5281/zenodo.50982}
+  url          = {https://doi.org/10.5281/zenodo.50982}
 }

--- a/papers/clawpack-5x/siamplain.bst
+++ b/papers/clawpack-5x/siamplain.bst
@@ -278,7 +278,7 @@ FUNCTION {format.url}
 FUNCTION {format.doi}
 { doi empty$
     { "" }
-    { "\href{http://dx.doi.org/" doi * "}{doi:\nolinkurl{" * doi * "}}" * }
+    { "\href{https://doi.org/" doi * "}{doi:\nolinkurl{" * doi * "}}" * }
   if$
 }
 


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected, there is no urgency here.

I'd simply like to suggest to update all static DOI links and the code that generates new DOI links accordingly.

Cheers!