### PR TITLE
Fix "Show on GitHub" and "Edit on GitHub" links

### DIFF
--- a/doc/ext/edit_on_github.py
+++ b/doc/ext/edit_on_github.py
@@ -44,5 +44,5 @@ def html_page_context(app, pagename, templatename, context, doctree):
 
 def setup(app):
     app.add_config_value('edit_on_github_project', '', True)
-    app.add_config_value('edit_on_github_branch', 'master', True)
+    app.add_config_value('edit_on_github_branch', 'dev', True)
     app.connect('html-page-context', html_page_context)


### PR DESCRIPTION
Fix "Show on GitHub" and "Edit on GitHub" links on the website by pointing
to the "dev" branch rather than the (non-existing) "master" branch.