### PR TITLE
Add Link to Slack Invite Form

### DIFF
--- a/doc/community.rst
+++ b/doc/community.rst
@@ -13,7 +13,7 @@ your question in these docs, please send a note to the
 
 Along with the google group we also have created a slack
 workspace.  If you would like to join please `fill out this 
-form
+form: 
 <https://forms.gle/HaWxefH5pTibgbgN8>`_.
 
 We are also starting to experiment with the following:

--- a/doc/community.rst
+++ b/doc/community.rst
@@ -11,6 +11,11 @@ your question in these docs, please send a note to the
 `claw-users google group
 <https://groups.google.com/forum/#!forum/claw-users>`_.
 
+Along with the google group we also have created a slack
+workspace.  If you would like to join please `fill out this 
+form
+<https://forms.gle/HaWxefH5pTibgbgN8>`_.
+
 We are also starting to experiment with the following:
 (Warning: they are not actively used.)
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -239,8 +239,7 @@ htmlhelp_basename = 'Clawpackdoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, document class [howto/manual]).
 latex_documents = [
-  ('index', 'Clawpack.tex', ur'Clawpack Documentation',
-   ur'RJL', 'manual'),
+  ('index', 'Clawpack.tex', r'Clawpack Documentation', r'RJL', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of


### PR DESCRIPTION
This adds a link to the form to get invited to the clawpack slack channel.

Also includes a conversion of `conf.py` to Python 3.