### PR TITLE
Add vtk to pyclaw.io

### DIFF
--- a/doc/pyclaw/io.rst
+++ b/doc/pyclaw/io.rst
@@ -11,25 +11,26 @@ Pyclaw supports the following input and output formats:
  * ASCII_ - ASCII file I/O, supports traditional clawpack format files
  * HDF5_ - HDF5 file I/O
  * NetCDF_ - NetCDF file I/O, support for NetCDF3 and NetCDF4 files
- 
-Each module contains two main routines ``read_<format>`` and 
-``write_<format>`` which :class:`~pyclaw.Solution` can call with the 
+ * VTK_ - `VTK <https://vtk.org>`__ VTK format (only output supported).
+
+Each module contains two main routines ``read_<format>`` and
+``write_<format>`` which :class:`~pyclaw.Solution` can call with the
 appropriate <format>.  In order to create a new file I/O extension the calling
 signature must match
 
 ::
 
     read_<format>(solution,frame,path,file_prefix,write_aux,options)
-    
+
 where the the inputs are
     :Input:
-     - *solution* - (:class:`~pyclaw.solution.Solution`) Pyclaw object to be 
+     - *solution* - (:class:`~pyclaw.solution.Solution`) Pyclaw object to be
        output
      - *frame* - (int) Frame number
      - *path* - (string) Root path
      - *file_prefix* - (string) Prefix for the file name.
-     - *write_aux* - (bool) Boolean controlling whether the associated 
-       auxiliary array should be written out.    
+     - *write_aux* - (bool) Boolean controlling whether the associated
+       auxiliary array should be written out.
      - *options* - (dict) Optional argument dictionary
 
 and
@@ -40,29 +41,29 @@ and
 
 where the inputs are
     :Input:
-     - *solution* - (:class:`~pyclaw.solution.Solution`) Pyclaw object to be 
+     - *solution* - (:class:`~pyclaw.solution.Solution`) Pyclaw object to be
        output
      - *frame* - (int) Frame number
      - *path* - (string) Root path
      - *file_prefix* - (string) Prefix for the file name.
-     - *write_aux* - (bool) Boolean controlling whether the associated 
-       auxiliary array should be written out.   
+     - *write_aux* - (bool) Boolean controlling whether the associated
+       auxiliary array should be written out.
      - *options* - (dict) Optional argument dictionary.
-     
+
 Note that both allow for an ``options`` dictionary that is format specific
-and should be documented thoroughly.  For examples of this usage, see the 
+and should be documented thoroughly.  For examples of this usage, see the
 HDF5_ and NetCDF_ modules.
- 
-HDF5_ and NetCDF_ support require installed libraries in order to work, please
+
+HDF5_, NetCDF_, and VTK_ support require installed libraries in order to work, please
 see the respective modules for details on how to obtain and install the
 libraries needed.
 
   .. note::
-  
-     Pyclaw automatically detects the availability of HDF5 and NetCDF file 
+
+     Pyclaw automatically detects the availability of HDF5 and NetCDF file
      support and will warn you if you try and use them without the proper
      libraries.
-     
+
 .. _ASCII:
 
 :mod:`pyclaw.fileio.ascii`
@@ -70,7 +71,7 @@ libraries needed.
 
 .. automodule:: clawpack.pyclaw.fileio.ascii
     :members:
-    
+
 .. _HDF5:
 
 :mod:`pyclaw.fileio.hdf5`
@@ -85,4 +86,12 @@ libraries needed.
 ===========================
 
 .. automodule:: clawpack.pyclaw.fileio.netcdf
+    :members:
+
+.. _VTK:
+
+:mod:`pyclaw.fileio.claw_vtk`
+=============================
+
+.. automodule:: clawpack.pyclaw.fileio.claw_vtk
     :members:


### PR DESCRIPTION
Adds vtk documentation to the pyclaw.io documentation. 

Note related PR at clawpack/pyclaw/pull/650 which addresses a formatting issue. 

I've tested that this builds correctly locally 
```
    cd $CLAW/doc/doc              # assumes this repo is at $CLAW/doc
    export SPHINX_WEB=False       # or ok to leave unset
    make html                     # requires Sphinx
    open _build/html/index.html
```

But lacking push permissions haven't done anything else yet re testing. 