### PR TITLE
Add NumFOCUS CoC to community page

### DIFF
--- a/doc/community.rst
+++ b/doc/community.rst
@@ -14,19 +14,19 @@ your question in these docs, please send a note to the
 `claw-users google group
 <https://groups.google.com/forum/#!forum/claw-users>`_.
 
-**Slack channel.**
-Along with the google group we also have created a slack
-workspace.  If you would like to join please `fill out this 
-form <https://forms.gle/HaWxefH5pTibgbgN8>`_.
+.. **Slack channel.**
+.. Along with the google group we also have created a slack
+.. workspace.  If you would like to join please `fill out this 
+.. form <https://forms.gle/HaWxefH5pTibgbgN8>`_.
 
-We are also starting to experiment with the following:
-(Warning: they are not actively used.)
+.. We are also starting to experiment with the following:
+.. (Warning: they are not actively used.)
 
-- `clawpack on Gitter <https://gitter.im/clawpack/public>`_
-  (Sign in with your github account if you want to post a comment or ask a
-  question.)
+.. - `clawpack on Gitter <https://gitter.im/clawpack/public>`_
+..   (Sign in with your github account if you want to post a comment or ask a
+..   question.)
 
-- `clawpack on twitter <https://twitter.com/clawpack>`_.
+.. - `clawpack on twitter <https://twitter.com/clawpack>`_.
 
 **Bug reports and suggested improvements**
 
@@ -57,6 +57,56 @@ The pages below give some tips for those who want to get involved.
 - Join or browse the `claw-dev google group
   <https://groups.google.com/forum/#!forum/claw-dev>`_
   to track discussion on the code.
+
+.. _code_of_conduct:
+
+NumFOCUS Code of Conduct
+------------------------
+
+As an `NumFOCUS <https://numfocus.org>`_ affiliated project we have elected to adopt the NumFOCUS code of
+conduct.  You can find the whole document at https://numfocus.org/code-of-conduct.
+
+The Short Version
+^^^^^^^^^^^^^^^^^
+
+NumFOCUS is dedicated to providing a harassment-free community for everyone,
+regardless of gender, sexual orientation, gender identity and expression,
+disability, physical appearance, body size, race, or religion. We do not
+tolerate harassment of community members in any form.
+
+Be kind to others. Do not insult or put down others. Behave professionally.
+Remember that harassment and sexist, racist, or exclusionary jokes are not
+appropriate for NumFOCUS.
+
+All communication should be appropriate for a professional audience including
+people of many different backgrounds. Sexual language and imagery is not
+appropriate.
+
+Thank you for helping make this a welcoming, friendly community for all.
+
+Long Version
+^^^^^^^^^^^^
+
+You can find the long version of the Code of Conduct on the NumFOCUS website 
+https://numfocus.org/code-of-conduct. 
+
+How To Report
+^^^^^^^^^^^^^
+
+If you feel that the Code of Conduct has been violated, feel free to submit a
+report, by using the form: `NumFOCUS Code of Conduct Reporting Form
+<https://numfocus.typeform.com/to/ynjGdT?typeform-source=numfocus.org>`_. 
+
+Who Will Receive Your Report
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Your report will be received and handled by NumFOCUS Code of Conduct Working
+Group; trained, and experienced contributors with diverse backgrounds. The
+group is making decisions independently from the project, PyData, NumFOCUS or
+any other organization. 
+
+You can learn more about the current group members, as well as the reporting
+procedure `HERE <https://numfocus.org/code-of-conduct>`_.
 
 .. _tutorials:
 


### PR DESCRIPTION
Add [NumFOCUS code of conduct](https://numfocus.org/code-of-conduct) to community page.