### PR TITLE
Add NumFOCUS Code of Conduct to Webpages

### DIFF
--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -97,7 +97,8 @@ report a bug or suggest an improvement.
 
 <p>
 We welcome new developers, see the 
-<a href="{{ pathto("developers") }}">Developers' Guide</a>
+<a href="{{ pathto("developers") }}">Developers' Guide</a>, the
+<a href="{{ pathto("code_of_conduct") }}">NumFOCUS Code of Conduct</a>,
 and the <a href="http://github.com/clawpack">GitHub Clawpack
 Organization</a>.
 

--- a/doc/code_of_conduct.rst
+++ b/doc/code_of_conduct.rst
@@ -10,14 +10,15 @@ https://numfocus.org/code-of-conduct.
 The Short Version
 -----------------
 
-NumFOCUS is dedicated to providing a harassment-free community for everyone,
-regardless of gender, sexual orientation, gender identity and expression,
-disability, physical appearance, body size, race, or religion. We do not
-tolerate harassment of community members in any form.
+NumFOCUS and the Clawpack community is dedicated to providing a
+harassment-free community for everyone, regardless of gender, sexual
+orientation, gender identity and expression, disability, physical appearance,
+body size, race, or religion. We do not tolerate harassment of community
+members in any form.
 
 Be kind to others. Do not insult or put down others. Behave professionally.
 Remember that harassment and sexist, racist, or exclusionary jokes are not
-appropriate for NumFOCUS.
+appropriate for NumFOCUS or Clawpack.
 
 All communication should be appropriate for a professional audience including
 people of many different backgrounds. Sexual language and imagery is not
@@ -43,8 +44,8 @@ Who Will Receive Your Report
 
 Your report will be received and handled by NumFOCUS Code of Conduct Working
 Group; trained, and experienced contributors with diverse backgrounds. The
-group is making decisions independently from the project, PyData, NumFOCUS or
-any other organization. 
+group is making decisions independently from the Clawpack project, PyData,
+NumFOCUS or any other organization. 
 
 You can learn more about the current group members, as well as the reporting
 procedure `HERE <https://numfocus.org/code-of-conduct>`_.

--- a/doc/code_of_conduct.rst
+++ b/doc/code_of_conduct.rst
@@ -1,0 +1,49 @@
+.. _code_of_conduct:
+
+NumFOCUS Code of Conduct
+------------------------
+
+As an `NumFOCUS <https://numfocus.org>`_ affiliated project we have elected to adopt the NumFOCUS code of
+conduct.  You can find the whole document at https://numfocus.org/code-of-conduct.
+
+The Short Version
+^^^^^^^^^^^^^^^^^
+
+NumFOCUS is dedicated to providing a harassment-free community for everyone,
+regardless of gender, sexual orientation, gender identity and expression,
+disability, physical appearance, body size, race, or religion. We do not
+tolerate harassment of community members in any form.
+
+Be kind to others. Do not insult or put down others. Behave professionally.
+Remember that harassment and sexist, racist, or exclusionary jokes are not
+appropriate for NumFOCUS.
+
+All communication should be appropriate for a professional audience including
+people of many different backgrounds. Sexual language and imagery is not
+appropriate.
+
+Thank you for helping make this a welcoming, friendly community for all.
+
+Long Version
+^^^^^^^^^^^^
+
+You can find the long version of the Code of Conduct on the NumFOCUS website 
+https://numfocus.org/code-of-conduct. 
+
+How To Report
+^^^^^^^^^^^^^
+
+If you feel that the Code of Conduct has been violated, feel free to submit a
+report, by using the form: `NumFOCUS Code of Conduct Reporting Form
+<https://numfocus.typeform.com/to/ynjGdT?typeform-source=numfocus.org>`_. 
+
+Who Will Receive Your Report
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Your report will be received and handled by NumFOCUS Code of Conduct Working
+Group; trained, and experienced contributors with diverse backgrounds. The
+group is making decisions independently from the project, PyData, NumFOCUS or
+any other organization. 
+
+You can learn more about the current group members, as well as the reporting
+procedure `HERE <https://numfocus.org/code-of-conduct>`_.

--- a/doc/code_of_conduct.rst
+++ b/doc/code_of_conduct.rst
@@ -1,13 +1,14 @@
 .. _code_of_conduct:
 
 NumFOCUS Code of Conduct
-------------------------
+========================
 
-As an `NumFOCUS <https://numfocus.org>`_ affiliated project we have elected to adopt the NumFOCUS code of
-conduct.  You can find the whole document at https://numfocus.org/code-of-conduct.
+As a `NumFOCUS <https://numfocus.org>`_ affiliated project we have elected to
+adopt the NumFOCUS code of conduct.  You can find the whole document at
+https://numfocus.org/code-of-conduct.
 
 The Short Version
-^^^^^^^^^^^^^^^^^
+-----------------
 
 NumFOCUS is dedicated to providing a harassment-free community for everyone,
 regardless of gender, sexual orientation, gender identity and expression,
@@ -25,20 +26,20 @@ appropriate.
 Thank you for helping make this a welcoming, friendly community for all.
 
 Long Version
-^^^^^^^^^^^^
+------------
 
 You can find the long version of the Code of Conduct on the NumFOCUS website 
 https://numfocus.org/code-of-conduct. 
 
 How To Report
-^^^^^^^^^^^^^
+-------------
 
 If you feel that the Code of Conduct has been violated, feel free to submit a
 report, by using the form: `NumFOCUS Code of Conduct Reporting Form
 <https://numfocus.typeform.com/to/ynjGdT?typeform-source=numfocus.org>`_. 
 
 Who Will Receive Your Report
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+----------------------------
 
 Your report will be received and handled by NumFOCUS Code of Conduct Working
 Group; trained, and experienced contributors with diverse backgrounds. The

--- a/doc/community.rst
+++ b/doc/community.rst
@@ -14,6 +14,8 @@ your question in these docs, please send a note to the
 `claw-users google group
 <https://groups.google.com/forum/#!forum/claw-users>`_.
 
+We have adopted the :ref:`code_of_conduct`.  Please see that page for more information.
+
 **Bug reports and suggested improvements**
 
 If you find a bug or want to suggest an improvement, please raise an issue

--- a/doc/developers.rst
+++ b/doc/developers.rst
@@ -13,6 +13,7 @@ See also the following pages from :ref:`contents-developers-resources`:
    howto_release
    regression
    git_versions
+   code_of_conduct
    
 
 .. contents::


### PR DESCRIPTION
Add [NumFOCUS code of conduct](https://numfocus.org/code-of-conduct) to webpages.

This supercedes #235.