### PR TITLE
Conform examples/tests to the met naming scheme

### DIFF
--- a/doc/met_forcing.rst
+++ b/doc/met_forcing.rst
@@ -19,7 +19,7 @@ Forcing families
 ================
 
 Met forcing comes in two families, selected in ``setrun.py`` through
-``rundata.surge_data`` (see :ref:`setrun_surge`):
+``rundata.met_data`` (see :ref:`setrun_surge`):
 
 **Parametric forcing**
    Wind and pressure fields are generated from a compact, evolving description
@@ -43,9 +43,9 @@ Selecting a forcing
 The explicit, preferred way to select forcing is a **family** plus a
 **subtype**::
 
-    rundata.surge_data.storm_family  = "parametric"   # or "gridded" / "none"
-    rundata.surge_data.storm_subtype = "holland80"    # model, or "gridded"
-    rundata.surge_data.storm_file    = "path/to/storm"
+    rundata.met_data.storm_family  = "parametric"   # or "gridded" / "none"
+    rundata.met_data.storm_subtype = "holland80"    # model, or "gridded"
+    rundata.met_data.storm_file    = "path/to/storm"
 
 See :ref:`setrun_surge` for the full attribute reference.
 
@@ -55,15 +55,15 @@ Python object model
 The Python side is organized around met forcing rather than only storms
 (:ref:`storm_module` is the API reference):
 
-- :class:`~clawpack.geoclaw.surge.track.Track` -- a generic evolving feature
+- :class:`~clawpack.geoclaw.met.track.Track` -- a generic evolving feature
   with a center over time, and
-  :class:`~clawpack.geoclaw.surge.track.StormTrack`, which adds storm metadata
+  :class:`~clawpack.geoclaw.met.track.StormTrack`, which adds storm metadata
   (max wind speed, radius of maximum winds, central pressure, ...).
-- :class:`~clawpack.geoclaw.surge.parametric.ParametricMetForcing` -- forcing
+- :class:`~clawpack.geoclaw.met.parametric.ParametricMetForcing` -- forcing
   from a parameterized model referencing a track.
-- :class:`~clawpack.geoclaw.surge.gridded.GriddedMetForcing` -- forcing from
+- :class:`~clawpack.geoclaw.met.gridded.GriddedMetForcing` -- forcing from
   external field datasets (OWI/ASCII, NetCDF).
-- :class:`~clawpack.geoclaw.surge.storm.Storm` -- a backwards-compatible
+- :class:`~clawpack.geoclaw.met.storm.Storm` -- a backwards-compatible
   wrapper retaining the historical ``read``/``write`` interface; new code can
   use the objects above directly.
 
@@ -91,6 +91,14 @@ Existing ``setrun.py`` scripts continue to work.  The changes are additive:
 - **Object model.** The ``Track`` / ``StormTrack`` / ``ParametricMetForcing`` /
   ``GriddedMetForcing`` classes above, with ``Storm`` retained as a
   compatibility wrapper.
+- **Python package renamed** ``clawpack.geoclaw.surge`` →
+  ``clawpack.geoclaw.met`` (the meteorological-forcing name).  Import from
+  ``clawpack.geoclaw.met`` (e.g. ``clawpack.geoclaw.met.storm``); the old
+  ``clawpack.geoclaw.surge`` still works but emits a ``DeprecationWarning``.  In
+  ``setrun.py`` use ``rundata.met_data`` (the former ``rundata.surge_data``
+  remains an accepted alias), and :class:`~clawpack.geoclaw.data.SurgeData` is
+  also exposed as ``MetData``.  The on-disk ``surge.data`` file and its format
+  are unchanged.
 
 .. note::
 

--- a/doc/netcdf.rst
+++ b/doc/netcdf.rst
@@ -304,7 +304,7 @@ required:
 .. code:: python
 
    import numpy as np
-   from clawpack.geoclaw.surge.storm import Storm
+   from clawpack.geoclaw.met.storm import Storm
 
    storm = Storm()
    storm.time_offset = np.datetime64('2012-08-29')

--- a/doc/quick_surge.rst
+++ b/doc/quick_surge.rst
@@ -47,11 +47,11 @@ The two inputs a surge computation needs
 Configuring the forcing in ``setrun.py``
 ========================================
 
-Storm forcing is configured through ``rundata.surge_data`` (full reference in
+Storm forcing is configured through ``rundata.met_data`` (full reference in
 :ref:`setrun_surge`).  The Ike example enables the wind and pressure source
 terms and selects a parametric Holland 1980 storm::
 
-    data = rundata.surge_data
+    data = rundata.met_data
     data.wind_forcing = True
     data.pressure_forcing = True
     data.drag_law = 1                      # Garratt wind drag
@@ -75,7 +75,7 @@ The GeoClaw-format storm file (``ike.storm`` above) is produced from a track in
 one of the ingest formats (ATCF, HURDAT, IBTrACS, JMA, TCVITALS).  Using the
 Python API (see :ref:`storm_module`)::
 
-    from clawpack.geoclaw.surge.storm import Storm
+    from clawpack.geoclaw.met.storm import Storm
     import numpy as np
 
     storm = Storm(path="track.dat", file_format="ATCF")
@@ -85,8 +85,8 @@ Python API (see :ref:`storm_module`)::
 Plotting and gauges
 ===================
 
-The example ``setplot.py`` uses the ``clawpack.geoclaw.surge.plot`` helpers
-(imported as ``surgeplot``) to plot the surface elevation, wind speed, and
+The example ``setplot.py`` uses the ``clawpack.geoclaw.met.plot`` helpers
+(imported as ``met_plot``) to plot the surface elevation, wind speed, and
 pressure fields, overlay the storm track, and plot gauge time series.  Gauges
 record the wind and pressure aux fields when ``rundata.gaugedata.aux_out_fields``
 includes the wind/pressure aux indices.
@@ -112,6 +112,6 @@ To model a different event, copy the Ike example directory and then:
 2. Obtain the storm track (e.g. an ATCF best-track file; see :ref:`surgedata`)
    and build the storm file as shown above, or point ``storm_file`` at a
    gridded descriptor for gridded forcing.
-3. Update ``setrun.py`` -- the domain extent, refinement regions, ``surge_data``
+3. Update ``setrun.py`` -- the domain extent, refinement regions, ``met_data``
    selection, gauges, and run time -- for the new event.
 4. Update ``setplot.py`` for the new domain and gauges.

--- a/doc/setrun_geoclaw.rst
+++ b/doc/setrun_geoclaw.rst
@@ -469,41 +469,47 @@ Fixed grid output
 Storm Specification Data
 ------------------------
 
-.. attribute:: rundata.surge_data.wind_forcing : bool
+.. note::
+
+   ``rundata.met_data`` is the meteorological-forcing name for these settings;
+   ``rundata.surge_data`` remains an accepted alias for the same object.  The
+   settings are written to the ``surge.data`` file that GeoClaw reads.
+
+.. attribute:: rundata.met_data.wind_forcing : bool
 
    Includes the wind forcing term if `True`.  The drag coefficient is specified
-   by `rundata.surge_data.drag_law`.
+   by `rundata.met_data.drag_law`.
 
-.. attribute:: rundata.surge_data.drag_law : integer
+.. attribute:: rundata.met_data.drag_law : integer
 
    This specifies how to deterimine the wind drag coefficient.  Valid options
    include include `0` implying use no wind drag (effectively eliminates the
    wind source term but still computes the wind), `1` uses the Garret wind
    drag law, and `2` uses the Powell (2006) wind drag law.
 
-.. attribute:: rundata.surge_data.pressure_forcing : bool
+.. attribute:: rundata.met_data.pressure_forcing : bool
 
    Includes the pressure forcing term if `True`.
 
-.. attribute:: rundata.surge_data.wind_index : int
+.. attribute:: rundata.met_data.wind_index : int
 
    Specifies at what index into the `aux` array the wind velocities are stored.
    Note that this is Python indexed in the setrun but will be corrected in the
    FORTRAN code (1 is added to the index).
 
-.. attribute:: rundata.surge_data.pressure_index : int
+.. attribute:: rundata.met_data.pressure_index : int
 
    Specifies at what index into the `aux` array the wind velocities are stored.
    Note that this is Python indexed in the setrun but will be corrected in the
    FORTRAN code (1 is added to the index).
 
-.. attribute:: rundata.surge_data.display_landfall_time : bool
+.. attribute:: rundata.met_data.display_landfall_time : bool
 
    Sets whether the console output displays time relative to land fall in days.
    In GeoClaw versions past 5.5 this only deterimines whether the time is 
    displayed in seconds or days.
 
-.. attribute:: rundata.surge_data.wind_refine : list
+.. attribute:: rundata.met_data.wind_refine : list
 
    Similar to the `speed_tolerance` data, cells are flagged for refinement at 
    a level if the magnitude of the wind velocity in m/s is greater than the 
@@ -514,13 +520,13 @@ Storm Specification Data
    40.0 would refine to level 4.  This can also be set to a boolean which if
    `False` disables wind based refinement.
 
-.. attribute:: rundata.surge_data.R_refine : list
+.. attribute:: rundata.met_data.R_refine : list
 
    Similar to the `wind_refine` data, cells are flagged based on the radial
    distance to the storm's center.  This can also be set to a boolean which if
    `False` disables storm radial based refinement.
 
-.. attribute:: rundata.surge_data.storm_family : string
+.. attribute:: rundata.met_data.storm_family : string
 
    The forcing family, and the preferred (explicit) way to select forcing
    together with ``storm_subtype``.  Valid values:
@@ -530,7 +536,7 @@ Storm Specification Data
     - ``"gridded"``: file-backed wind/pressure fields (OWI/ASCII or NetCDF).
     - ``"none"``: forcing off.
 
-.. attribute:: rundata.surge_data.storm_subtype : string
+.. attribute:: rundata.met_data.storm_subtype : string
 
    The forcing subtype within the family.  For ``"parametric"`` this is a model
    name -- one of ``"holland80"``, ``"holland2008"``, ``"holland2010"``,
@@ -538,7 +544,7 @@ Storm Specification Data
    ``"demaria"``, or ``"willoughby"``.  For ``"gridded"`` use ``"gridded"``
    (the concrete OWI/NetCDF format is carried by the storm descriptor file).
 
-.. attribute:: rundata.surge_data.storm_specification_type : int or string
+.. attribute:: rundata.met_data.storm_specification_type : int or string
 
    Legacy forcing selector, retained for backwards compatibility and still
    fully supported.  Used when ``storm_family``/``storm_subtype`` are not set;
@@ -551,7 +557,7 @@ Storm Specification Data
    2008, ``9`` Willoughby); a negative value (``-1``) selects gridded/data
    forcing.
 
-.. attribute:: rundata.surge_data.storm_file : string
+.. attribute:: rundata.met_data.storm_file : string
 
    Specifies the path to the storm data.  IF `storm_specification_type > 0` then
    this should point to a GeoClaw formatted storm file (see :ref:`storm_module` for
@@ -559,7 +565,7 @@ Storm Specification Data
    to files specifying the storm or a single file depending on the type of input
    data.
 
-.. attribute:: rundata.surge_data.storm_time_scale : float
+.. attribute:: rundata.met_data.storm_time_scale : float
 
    A multiplicative scale factor applied to the storm's time axis.  Values
    greater than 1 slow the storm down (it takes longer to traverse the
@@ -568,19 +574,19 @@ Storm Specification Data
    creating synthetic storms whose tracks are spatially identical to a
    historical event but travel at a different speed.
 
-.. attribute:: rundata.surge_data.t_ramp_on : float
+.. attribute:: rundata.met_data.t_ramp_on : float
 
    Number of seconds over which the wind/pressure forcing ramps on after the
    simulation start time.  ``0.0`` (the default) disables the onset ramp.
    Useful for avoiding an impulsive start when the forcing is already
    significant at ``t0``.
 
-.. attribute:: rundata.surge_data.t_ramp_off : float
+.. attribute:: rundata.met_data.t_ramp_off : float
 
    Number of seconds over which the wind/pressure forcing ramps off before the
    final time.  ``0.0`` (the default) disables the cutoff ramp.
 
-.. attribute:: rundata.surge_data.rotation_override : int or string
+.. attribute:: rundata.met_data.rotation_override : int or string
 
    Overrides the hemisphere-based sense of the storm's rotation.  The default
    (``0`` or ``"normal"``) chooses the rotation from the hemisphere of the

--- a/doc/storm_module.rst
+++ b/doc/storm_module.rst
@@ -6,7 +6,7 @@ Meteorological Forcing Python API
 
 .. seealso::
    - :ref:`met_forcing` -- overview of met forcing and the object model
-   - :ref:`setrun_surge` -- the ``rundata.surge_data`` attribute reference
+   - :ref:`setrun_surge` -- the ``rundata.met_data`` attribute reference
    - :ref:`netcdf_input` -- gridded NetCDF met forcing
 
 This is the Python API for building and writing GeoClaw meteorological forcing.
@@ -22,7 +22,7 @@ descriptor (``write_data``).
 Storm (compatibility wrapper)
 -----------------------------
 
-.. automodule:: clawpack.geoclaw.surge.storm
+.. automodule:: clawpack.geoclaw.met.storm
    :members:
    :undoc-members:
    :show-inheritance:
@@ -30,7 +30,7 @@ Storm (compatibility wrapper)
 Track and StormTrack
 --------------------
 
-.. automodule:: clawpack.geoclaw.surge.track
+.. automodule:: clawpack.geoclaw.met.track
    :members:
    :undoc-members:
    :show-inheritance:
@@ -38,7 +38,7 @@ Track and StormTrack
 Parametric met forcing
 ----------------------
 
-.. automodule:: clawpack.geoclaw.surge.parametric
+.. automodule:: clawpack.geoclaw.met.parametric
    :members:
    :undoc-members:
    :show-inheritance:
@@ -46,7 +46,7 @@ Parametric met forcing
 Gridded met forcing
 -------------------
 
-.. automodule:: clawpack.geoclaw.surge.gridded
+.. automodule:: clawpack.geoclaw.met.gridded
    :members:
    :undoc-members:
    :show-inheritance:
@@ -54,17 +54,19 @@ Gridded met forcing
 Workflow tools
 --------------
 
-.. automodule:: clawpack.geoclaw.surge.tools
+.. automodule:: clawpack.geoclaw.met.tools
    :members:
    :undoc-members:
    :show-inheritance:
 
-Surge data object
------------------
+Met forcing data object
+-----------------------
 
 The ``surge.data`` file written by ``setrun.py`` is described by
-:class:`~clawpack.geoclaw.data.SurgeData`; see :ref:`setrun_surge` for the
-per-attribute reference.
+:class:`~clawpack.geoclaw.data.SurgeData` (also available under the alias
+``MetData``); it is set in ``setrun.py`` as ``rundata.met_data`` (the former
+``rundata.surge_data`` remains an accepted alias).  See :ref:`setrun_surge` for
+the per-attribute reference.
 
 .. autoclass:: clawpack.geoclaw.data.SurgeData
    :members:

--- a/doc/surgedata.rst
+++ b/doc/surgedata.rst
@@ -8,7 +8,7 @@ Sources for Storm Surge Data
 .. seealso::
    - :ref:`met_forcing` -- meteorological forcing overview and object model
    - :ref:`quick_surge` -- storm surge quick start
-   - :ref:`setrun_surge` -- the ``rundata.surge_data`` reference
+   - :ref:`setrun_surge` -- the ``rundata.met_data`` reference
 
 For storm surge computations the input data is very similar to tsunamis save
 for the specification of the forcing storm (as opposed to an earthquake).  There


### PR DESCRIPTION
Cosmetic follow-up to the surge->met package rename: examples/tests now use met_plot/geodata aliases, rundata.met_data, and met-forcing wording. The surge.data filename, SurgeData class, met.plot.surge_afteraxes, and the storm-surge/ directory are unchanged (deferred to a future major version).
